### PR TITLE
SIP5 Reporting and Logic update

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ docker compose up
 
 The application will be served on http://127.0.0.1:8009 (I.E. typing localhost/docs in your browser will load the swagger documentation)
 
-Full list of APIs available you can check [here](https://editor-next.swagger.io/?url=https://gist.githubusercontent.com/JoleVLF/b1bcdd77ac82aeb115a6c94fb3dadbdc/raw/32df1d94947b67dcc70f730a629d7c91161e532f/api.json)
+Full list of APIs available you can check [here](https://editor-next.swagger.io/?url=https://gist.githubusercontent.com/JoleVLF/42227cda7f1c3869abad5ac4cb7e8ab5/raw/e7cfc9b8642c0551bdfc14fc27362c8bb39515cb/dist.json)
 # Documentation
 <h3>GET</h3>
 
@@ -83,8 +83,14 @@ Response is generated PDF file.
 - **Type**: `UploadFile`
 - **Description**: API processes the data directly to generate the report if data passed. This parameter is not required and when it is, must be provided as an `UploadFile`.
 
+- ### from_date
+- **Type**: `date`
+- **Description**:  Optional date filter (from which data is filtered)
 
-
+- ### to_date
+- **Type**: `date`
+- **Description**:  AOptional date filter (until which data is filtered)
+- 
 ## Response
 
 Response is uuid of generated PDF file.
@@ -99,8 +105,19 @@ Response is uuid of generated PDF file.
 
 ### observation_type_name
 - **Type**: `str`
-- **Description**:  All Farm Calendar Observation Type values are possible as input
+- **Description**:  All Farm Calendar Observation Type values are possible as input (optional)
 
+### operation_id
+- **Type**: `uudi str`
+- **Description**:  ID of operation for which PDF is generated (optional)
+
+- ### from_date
+- **Type**: `date`
+- **Description**:  Optional date filter (from which data is filtered)
+
+- ### to_date
+- **Type**: `date`
+- **Description**:  AOptional date filter (until which data is filtered)
 
 ### data
 - **Type**: `UploadFile`
@@ -140,6 +157,14 @@ When service is run without Gatekeeper data must be provided in .json file forma
 ### status
 - **Type**: `Optional[int]`
 - **Description**: The status code associated with the animal or the transaction. It is an optional integer field. If not specified, it defaults to `None`.
+
+- ### from_date
+- **Type**: `date`
+- **Description**:  Optional date filter (from which data is filtered)
+
+- ### to_date
+- **Type**: `date`
+- **Description**:  AOptional date filter (until which data is filtered)
 
 ### data
 - **Type**: `UploadFile`

--- a/README.md
+++ b/README.md
@@ -99,12 +99,8 @@ Response is uuid of generated PDF file.
 
 ### observation_type_name
 - **Type**: `str`
-- **Description**: The name of the observation type for the report. The value of this parameter must be one of the following options:
-  - "Pesticides"
-  - "Irrigation"
-  - "Fertilization"
-  - "CropStressIndicator"
-  - "CropGrowthObservation"
+- **Description**:  All Farm Calendar Observation Type values are possible as input
+
 
 ### data
 - **Type**: `UploadFile`

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Response is uuid of generated PDF file.
 
 ### observation_type_name
 - **Type**: `str`
-- **Description**:  All Farm Calendar Observation Type values are possible as input (optional)
+- **Description**:  All Farm Calendar Observation Type values are possible as input (optional). If operation_id provided not used.
 
 ### operation_id
 - **Type**: `uudi str`
@@ -113,11 +113,11 @@ Response is uuid of generated PDF file.
 
 - ### from_date
 - **Type**: `date`
-- **Description**:  Optional date filter (from which data is filtered)
+- **Description**:  Optional date filter (from which data is filtered). If operation_id provided not used.
 
 - ### to_date
 - **Type**: `date`
-- **Description**:  AOptional date filter (until which data is filtered)
+- **Description**:  AOptional date filter (until which data is filtered). If operation_id provided not used.
 
 ### data
 - **Type**: `UploadFile`

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -88,16 +88,20 @@ async def generate_irrigation_report(
 
 @router.post("/compost-report/", response_model=PDF)
 async def generate_generic_observation_report(
-    observation_type_name: str,
-    background_tasks: BackgroundTasks,
+        background_tasks: BackgroundTasks,
+
+        observation_type_name: str = None,
+
     token=Depends(deps.get_current_user),
     data: UploadFile = None,
+    operation_id: str = None,
 ):
     """
     Generates Observation Report PDF file
     All Farm Calendar Observation Type values are possible as input
 
     """
+
     uuid_v4 = str(uuid.uuid4())
     user_id = (
         decode_jwt_token(token)["user_id"]
@@ -112,6 +116,7 @@ async def generate_generic_observation_report(
         token=token,
         data=data,
         pdf_file_name=uuid_of_pdf,
+        operation_id=operation_id
     )
 
     return PDF(uuid=uuid_v4)

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -95,15 +95,9 @@ async def generate_generic_observation_report(
 ):
     """
     Generates Observation Report PDF file
-    possible_names = ["Pesticides", "Irrigation", "Fertilization", "CropStressIndicator", "CropGrowthObservation"]
-
+    All Farm Calendar Observation Type values are possible as input
 
     """
-    if observation_type_name == "CropGrowthObservation":
-        observation_type_name = "Crop Growth Stage Observation"
-
-    if observation_type_name == "CropStressIndicator":
-        observation_type_name = "Crop Stress Indicator"
     uuid_v4 = str(uuid.uuid4())
     user_id = (
         decode_jwt_token(token)["user_id"]

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import uuid
 from typing import Optional
@@ -57,6 +58,8 @@ async def generate_irrigation_report(
     background_tasks: BackgroundTasks,
     token=Depends(deps.get_current_user),
     data: UploadFile = None,
+        from_date: datetime.date = None,
+        to_date: datetime.date = None
 ):
     """
     Generates Irrigation Report PDF file
@@ -81,6 +84,8 @@ async def generate_irrigation_report(
         data=data,
         token=token,
         pdf_file_name=uuid_of_pdf,
+    from_date=from_date,
+    to_date=to_date
     )
 
     return PDF(uuid=uuid_v4)
@@ -88,13 +93,13 @@ async def generate_irrigation_report(
 
 @router.post("/compost-report/", response_model=PDF)
 async def generate_generic_observation_report(
-        background_tasks: BackgroundTasks,
-
-        observation_type_name: str = None,
-
+    background_tasks: BackgroundTasks,
+    observation_type_name: str = None,
     token=Depends(deps.get_current_user),
     data: UploadFile = None,
     operation_id: str = None,
+    from_date: datetime.date = None,
+    to_date: datetime.date = None
 ):
     """
     Generates Observation Report PDF file
@@ -116,7 +121,9 @@ async def generate_generic_observation_report(
         token=token,
         data=data,
         pdf_file_name=uuid_of_pdf,
-        operation_id=operation_id
+        operation_id=operation_id,
+        from_date=from_date,
+        to_date=to_date,
     )
 
     return PDF(uuid=uuid_v4)
@@ -131,6 +138,8 @@ async def generate_animal_report(
     parcel: Optional[UUID4] = None,
     status: Optional[int] = None,
     data: UploadFile = None,
+        from_date: datetime.date = None,
+        to_date: datetime.date = None
 ):
     """
     Generates Animal Report PDF file
@@ -166,6 +175,8 @@ async def generate_animal_report(
         token=token,
         params=params,
         pdf_file_name=uuid_of_pdf,
+    from_date=from_date,
+    to_date=to_date
     )
 
     return PDF(uuid=uuid_v4)

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -24,7 +24,7 @@ from fastapi.responses import FileResponse
 router = APIRouter()
 
 
-@router.get("/{report_id}", response_class=FileResponse)
+@router.get("/{report_id}/", response_class=FileResponse)
 def retrieve_generated_pdf(
     report_id: str,
     token=Depends(deps.get_current_user),

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -36,7 +36,7 @@ def get_current_user(
                 json={"token": token, "token_type": "access"},
             )
 
-            if response.status_code == 400:
+            if str(response.status_code)[0] != "2":
                 raise HTTPException(status_code=400, detail="Error, bad jwt token.")
             return token
         else:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -27,9 +27,13 @@ class Settings(BaseSettings):
         "irrigations": "/IrrigationOperations/",
         "activity_types": "/FarmCalendarActivityTypes/",
         "observations": "/Observations/",
+        "operations": "/CompostOperations/",
         "activities": "/FarmCalendarActivities/",
         "parcel": "/FarmParcels/",
         "animals": "/FarmAnimals/",
+        "materials": "/AddRawMaterialOperations/",
+        "machines": "/AgriculturalMachines/",
+        "farm": "/Farm/"
     }
 
     PDF_DIRECTORY: str = "user_reports/"

--- a/app/schemas/compost.py
+++ b/app/schemas/compost.py
@@ -20,6 +20,7 @@ class CropObservation(BaseModel):
     details: str
     hasStartDatetime: Optional[datetime] = None
     hasEndDatetime: Optional[datetime] = None
+    phenomenonTime: Optional[datetime] = None
     responsibleAgent: Optional[str] = None
     usesAgriculturalMachinery: List[dict] = []
     hasResult: Optional[HasResult] = None
@@ -40,3 +41,5 @@ class Operation(BaseModel):
     hasEndDatetime: Optional[datetime] = None
     responsibleAgent: Optional[str] = None
     usesAgriculturalMachinery: List[dict] = []
+    isOperatedOn: dict = None
+    hasMeasurement: list[dict] = None

--- a/app/schemas/compost.py
+++ b/app/schemas/compost.py
@@ -4,26 +4,26 @@ from datetime import datetime
 
 
 class QuantityValue(BaseModel):
-    type_: str = Field(alias="@type")
+    type: str = Field(alias="@type")
     unit: str = ""
     numericValue: float = 0.0
 
 
 class CompostMaterial(BaseModel):
-    type_: str = Field(alias="@type")
+    type: str = Field(alias="@type")
     typeName: str = ""
     quantityValue: Optional[QuantityValue] = None
 
 
 class ActivityType(BaseModel):
-    type_: str = Field(alias="@type")
-    id_: str = Field(alias="@id")
+    type: str = Field(alias="@type")
+    id: str = Field(alias="@id")
 
 
 class HasResult(BaseModel):
     type: str = Field(alias="@type")
     id: str = Field(alias="@id")
-    unit: Optional[str] = (None,)
+    unit: Optional[str] = None
     hasValue: Optional[str] = None
 
 
@@ -42,7 +42,6 @@ class CropObservation(BaseModel):
     usesAgriculturalMachinery: List[dict] = []
     hasResult: Optional[HasResult] = None
     isMeasuredIn: Optional[str] = None
-    relatesToProperty: Optional[str] = None
     observedProperty: Optional[str] = None
 
 
@@ -56,7 +55,7 @@ class Operation(BaseModel):
     details: str = ""
     hasStartDatetime: Optional[datetime] = None
     hasEndDatetime: Optional[datetime] = None
-    responsibleAgent: Optional[str] = None
+    responsibleAgent: Optional[str] = ""
     usesAgriculturalMachinery: List[dict] = []
     isOperatedOn: dict = None
     hasMeasurement: list[dict] = None

--- a/app/schemas/compost.py
+++ b/app/schemas/compost.py
@@ -3,6 +3,23 @@ from typing import List, Optional
 from datetime import datetime
 
 
+class QuantityValue(BaseModel):
+    type_: str = Field(alias="@type")
+    unit: str = ""
+    numericValue: float = 0.0
+
+
+class CompostMaterial(BaseModel):
+    type_: str = Field(alias="@type")
+    typeName: str = ""
+    quantityValue: Optional[QuantityValue] = None
+
+
+class ActivityType(BaseModel):
+    type_: str = Field(alias="@type")
+    id_: str = Field(alias="@id")
+
+
 class HasResult(BaseModel):
     type: str = Field(alias="@type")
     id: str = Field(alias="@id")
@@ -35,11 +52,17 @@ class Operation(BaseModel):
     type: str = Field(alias="@type")
     id: str = Field(alias="@id")
     activityType: dict
-    title: str
-    details: str
+    title: str = ""
+    details: str = ""
     hasStartDatetime: Optional[datetime] = None
     hasEndDatetime: Optional[datetime] = None
     responsibleAgent: Optional[str] = None
     usesAgriculturalMachinery: List[dict] = []
     isOperatedOn: dict = None
     hasMeasurement: list[dict] = None
+    hasNestedOperation: list[dict] = None
+
+
+class AddRawMaterialOperation(Operation):
+    usesAgriculturalMachinery: List = []
+    hasCompostMaterial: List[CompostMaterial] = []

--- a/app/utils/animals_report.py
+++ b/app/utils/animals_report.py
@@ -93,15 +93,11 @@ def process_animal_data(
             params=params,
         )
 
-        if not json_data:
-            raise HTTPException(status_code=400, detail="No animal data found.")
-
     else:
         json_data = json.load(data.file)
 
     animals = parse_animal_data(json_data)
-    if not animals:
-        return
+
     try:
         anima_pdf = create_pdf_from_animals(animals)
     except Exception:

--- a/app/utils/animals_report.py
+++ b/app/utils/animals_report.py
@@ -5,7 +5,7 @@ from typing import List, Union
 from fastapi import HTTPException
 
 from core import settings
-from utils import EX, add_fonts, decode_jwt_token
+from utils import EX, add_fonts, decode_jwt_token, decode_dates_filters
 from schemas.animals import *
 from utils.json_handler import make_get_request
 
@@ -81,12 +81,15 @@ def create_pdf_from_animals(animals: List[Animal]):
 
 
 def process_animal_data(
-    token: dict[str, str], pdf_file_name: str, params: dict | None = None, data=None
+        token: dict[str, str], pdf_file_name: str, params: dict | None = None, data=None,
+        from_date: datetime.date = None,
+        to_date: datetime.date = None
 ) -> None:
     """
     Process animal data and generate PDF report
     """
     if params:
+        decode_dates_filters(params, from_date, to_date)
         json_data = make_get_request(
             url=f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["animals"]}',
             token=token,

--- a/app/utils/farm_calendar_report.py
+++ b/app/utils/farm_calendar_report.py
@@ -92,6 +92,7 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
                 pdf.set_font("FreeSerif", "", 10)
                 pdf.multi_cell(0, 8, farm, ln=True, fill=True)
 
+
         cp_id = operation.isOperatedOn.get("@id", "N/A").split(":")[-1] if operation.isOperatedOn else 'N/A'
         start_date = operation.hasStartDatetime.strftime("%d/%m/%Y") if operation.hasStartDatetime else operation.phenomenonTime
         end_date = operation.hasEndDatetime.strftime("%d/%m/%Y") if operation.hasEndDatetime else "N/A"
@@ -115,6 +116,25 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
         pdf.cell(40, 8, "Compost Pile:")
         pdf.set_font("FreeSerif", "", 10)
         pdf.multi_cell(0, 8, str(cp_id), ln=True, fill=True)
+
+        pdf.set_font("FreeSerif", "B", 10)
+        pdf.cell(40, 8, "Initial Materials:")
+        pdf.ln(15)
+        if calendar_data.materials:
+            with pdf.table(text_align="CENTER", padding=0.5, v_align=VAlign.M) as table:
+                pdf.set_font("FreeSerif", "", 10)
+                row = table.row()
+                row.cell("Name")
+                row.cell("Unit")
+                row.cell("Numeric value")
+                pdf.set_font("FreeSerif", "", 9)
+                row = table.row()
+                x = calendar_data.materials[0].hasCompostMaterial[0] if calendar_data.materials[0].hasCompostMaterial else None
+                row.cell(x.typeName if x else 'N/A')
+                row.cell(x.quantityValue.unit if x.quantityValue else 'N/A')
+                row.cell(str(x.quantityValue.numericValue) if x.quantityValue else 'N/A')
+
+
     pdf.set_fill_color(0, 255, 255)
     if len(calendar_data.operations) > 1:
         with pdf.table(text_align="CENTER", padding=0.5) as table:
@@ -279,9 +299,6 @@ def process_farm_calendar_data(
                     )
 
                     del params["name"]
-                    operations = []
-                    observations = []
-                    materials = []
 
                     if farm_activity_type_info:
                         params["activity_type"] = farm_activity_type_info[0]["@id"].split(":")[3]
@@ -338,7 +355,6 @@ def process_farm_calendar_data(
                             token=token,
                             params=params
                         )
-
 
             calendar_data = FarmCalendarData(
                 activity_type_info=observation_type_name,

--- a/app/utils/farm_calendar_report.py
+++ b/app/utils/farm_calendar_report.py
@@ -51,6 +51,7 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
     pdf.add_page()
 
     EX.ln(pdf)
+
     pdf.set_font("FreeSerif", "B", 14)
     pdf.cell(0, 10, f"{calendar_data.activity_type} Report", ln=True, align="C")
     pdf.set_font("FreeSerif", style="", size=9)
@@ -59,6 +60,7 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
 
     pdf.set_font("FreeSerif", "B", 12)
     pdf.cell(0, 10, "Activity Type Information", ln=True, align="L")
+    pdf.set_fill_color(230, 230, 230)
 
     y_position = pdf.get_y()
     line_end_x = pdf.w - pdf.l_margin - pdf.r_margin
@@ -83,12 +85,12 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
                 pdf.set_font("FreeSerif", "B", 10)
                 pdf.cell(40, 8, "Parcel Location:")
                 pdf.set_font("FreeSerif", "", 10)
-                pdf.multi_cell(0, 8, address, ln=True)
+                pdf.multi_cell(0, 8, address, ln=True, fill=True)
 
                 pdf.set_font("FreeSerif", "B", 10)
-                pdf.cell(40, 8, "Farm information:")
+                pdf.cell(40, 8, "Farm information:",)
                 pdf.set_font("FreeSerif", "", 10)
-                pdf.multi_cell(0, 8, farm, ln=True)
+                pdf.multi_cell(0, 8, farm, ln=True, fill=True)
 
         cp_id = operation.isOperatedOn.get("@id", "N/A").split(":")[-1] if operation.isOperatedOn else 'N/A'
         start_date = operation.hasStartDatetime.strftime("%d/%m/%Y") if operation.hasStartDatetime else operation.phenomenonTime
@@ -97,23 +99,23 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
         pdf.set_font("FreeSerif", "B", 10)
         pdf.cell(40, 8, "Details:")
         pdf.set_font("FreeSerif", "", 10)
-        pdf.multi_cell(0, 8, str(operation.details), ln=True)
+        pdf.multi_cell(0, 8, str(operation.details), ln=True, fill=True)
 
         pdf.set_font("FreeSerif", "B", 10)
         pdf.cell(40, 8, "Starting Date:")
         pdf.set_font("FreeSerif", "", 10)
-        pdf.multi_cell(0, 8, str(start_date), ln=True)
+        pdf.multi_cell(0, 8, str(start_date), ln=True, fill=True)
 
         pdf.set_font("FreeSerif", "B", 10)
         pdf.cell(40, 8, "Ending Date:")
         pdf.set_font("FreeSerif", "", 10)
-        pdf.multi_cell(0, 8, str(end_date), ln=True)
+        pdf.multi_cell(0, 8, str(end_date), ln=True, fill=True)
 
         pdf.set_font("FreeSerif", "B", 10)
         pdf.cell(40, 8, "Compost Pile:")
         pdf.set_font("FreeSerif", "", 10)
-        pdf.multi_cell(0, 8, str(cp_id), ln=True)
-    style = FontFace(fill_color=(180, 196, 36))
+        pdf.multi_cell(0, 8, str(cp_id), ln=True, fill=True)
+    pdf.set_fill_color(0, 255, 255)
     if len(calendar_data.operations) > 1:
         with pdf.table(text_align="CENTER", padding=0.5) as table:
 
@@ -122,7 +124,6 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
             pdf.ln(5)
 
             row = table.row()
-            row.style = style
             pdf.set_font("FreeSerif", "B", 10)
             row.cell("Title")
             row.cell("Details")
@@ -132,10 +133,9 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
             row.cell("Machinery IDs")
             row.cell("Compost Pile")
             pdf.set_font("FreeSerif", "", 9)
-            style = FontFace(fill_color=(255, 255, 240))
+            pdf.set_fill_color(255, 255, 240)
             for operation in calendar_data.operations:
                 row = table.row()
-                row.style = style
                 row.cell(operation.title)
                 row.cell(operation.details)
                 row.cell(
@@ -161,7 +161,7 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
 
     if calendar_data.observations:
         pdf.ln()
-        style = FontFace(fill_color=(180, 196, 36))
+        pdf.set_fill_color(0, 255, 255	)
 
         pdf.set_font("FreeSerif", "B", 12)
         pdf.cell(0, 10, "Observations", ln=True)
@@ -169,7 +169,6 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
 
         with pdf.table(text_align="CENTER", padding=0.5, v_align=VAlign.M) as table:
             row = table.row()
-            row.style = style
             pdf.set_font("FreeSerif", "B", 10)
             row.cell("Value info")
             row.cell("Observed Property")
@@ -177,12 +176,10 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
             row.cell("Start")
             row.cell("End")
             row.cell("Responsible Agent")
-            row.cell("Machinery IDs")
             pdf.set_font("FreeSerif", "", 9)
             for x in calendar_data.observations:
                 row = table.row()
-                style = FontFace(fill_color=(255, 255, 240))
-                row.style = style
+                pdf.set_fill_color(255, 255, 240)
                 (
                     row.cell(f"{x.hasResult.hasValue} ({x.hasResult.unit})")
                     if x.hasResult
@@ -199,21 +196,10 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
                 row.cell(f"{x.hasEndDatetime.strftime('%d/%m/%Y') if x.hasEndDatetime else x.hasEndDatetime}")
                 row.cell(f"R{x.responsibleAgent if x.responsibleAgent else 'N/A'}")
 
-                if x.usesAgriculturalMachinery:
-                    machinery_ids = ", ".join(
-                        [
-                            machinery.get("@id", "N/A").split(":")[3]
-                            for machinery in x.usesAgriculturalMachinery
-                        ]
-                    )
-                    row.cell(f"{machinery_ids}")
-                else:
-                    row.cell("N/A")
-
 
     if calendar_data.materials:
         pdf.ln()
-        style = FontFace(fill_color=(180, 196, 36))
+        pdf.set_fill_color(0, 255, 255)
 
         pdf.set_font("FreeSerif", "B", 12)
         pdf.cell(0, 10, "Raw materials added", ln=True)
@@ -221,7 +207,6 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
 
         with pdf.table(text_align="CENTER", padding=0.5, v_align=VAlign.M) as table:
             row = table.row()
-            row.style = style
             pdf.set_font("FreeSerif", "B", 10)
             row.cell("Name")
             row.cell("Unit")
@@ -230,8 +215,7 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData, token: dict[str, s
             for material in calendar_data.materials:
                 for x in material.hasCompostMaterial:
                     row = table.row()
-                    style = FontFace(fill_color=(255, 255, 240))
-                    row.style = style
+                    pdf.set_fill_color(255, 255, 240)
                     row.cell(x.typeName)
                     row.cell(x.quantityValue.unit if x.quantityValue else 'N/A')
                     row.cell(str(x.quantityValue.numericValue) if x.quantityValue else 'N/A')

--- a/app/utils/farm_calendar_report.py
+++ b/app/utils/farm_calendar_report.py
@@ -68,52 +68,24 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData) -> EX:
             row = table.row()
             row.style = style
             pdf.set_font("FreeSerif", "B", 10)
-            row.cell(f"Title")
-
-            row.cell(f"Details")
-
-            row.cell(
-                f"Start",
-            )
-            row.cell("End")
-            row.cell("Responsible Agent")
-            row.cell("Type")
-            row.cell("Machinery IDs")
-            row.cell("Operated On")
+            row.cell("Title"); row.cell("Details"); row.cell("Start"); row.cell("End")
+            row.cell("Responsible Agent"); row.cell("Type");
+            row.cell("Machinery IDs"); row.cell("Operated On")
             pdf.set_font("FreeSerif", "", 9)
-            style = FontFace(fill_color=(255, 255, 240			))
+            style = FontFace(fill_color=(255, 255, 240))
             for operation in calendar_data.operations:
-
                 row = table.row()
                 row.style = style
 
-                row.cell(f"{operation.title}")
-
-                row.cell( f"{operation.details}",)
-
-                if operation.hasStartDatetime:
-                    row.cell(
-                        f"{operation.hasStartDatetime}",
+                row.cell(operation.title); row.cell(operation.details)
+                row.cell(
+                        f"{operation.hasStartDatetime if operation.hasStartDatetime else 'N/A'}",
                     )
-                else:
-                    row.cell(
-                    "N/a"
-                    )
-                if operation.hasEndDatetime:
-                    row.cell(
-                        f"{operation.hasEndDatetime}",
-                    )
-                else:
-                    row.cell(
-                        f"{operation.hasEndDatetime}",
-                    )
-                (
-                    row.cell(f"{operation.responsibleAgent}")
-                    if operation.responsibleAgent
-                    else row.cell(
-                        f"{operation.hasEndDatetime}",
-                    )
+                row.cell(
+                    f"{operation.hasEndDatetime if operation.hasEndDatetime else 'N/A'} ",
                 )
+
+                row.cell(f"{operation.responsibleAgent if operation.responsibleAgent else 'N/A'}")
                 row.cell(calendar_data.activity_type)
 
                 if operation.usesAgriculturalMachinery:
@@ -136,6 +108,7 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData) -> EX:
                     row.cell(
                         "N/A",
                     )
+
     if calendar_data.observations:
         pdf.ln()
         style = FontFace(fill_color=(180, 196, 36	))
@@ -148,17 +121,10 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData) -> EX:
             row = table.row()
             row.style = style
             pdf.set_font("FreeSerif", "B", 10)
-            row.cell("Value")
-            row.cell("Value unit")
-            row.cell("Property")
-            row.cell("Observed Property")
-            row.cell("Details")
-            row.cell("Start")
-            row.cell("End")
-            row.cell("Responsible Agent")
-            row.cell("Machinery IDs")
+            row.cell("Value"); row.cell("Value unit"); row.cell("Property")
+            row.cell("Observed Property"); row.cell("Details"); row.cell("Start")
+            row.cell("End"); row.cell("Responsible Agent"); row.cell("Machinery IDs")
             pdf.set_font("FreeSerif", "", 9)
-
             for x in calendar_data.observations:
                 row = table.row()
                 style = FontFace(fill_color=(255, 255, 240		))
@@ -186,24 +152,9 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData) -> EX:
                 row.cell(f"{x.details}")
 
                 start_time = x.hasStartDatetime if x.hasStartDatetime else x.phenomenonTime
-                if  start_time:
-                    row.cell(
-                        f"{start_time}"
-                    )
-                else:
-                    row.cell("N/A")
-
-                if x.hasEndDatetime:
-                    row.cell(
-                        f"{x.hasEndDatetime}",
-                    )
-                else:
-                    row.cell("N/A")
-                (
-                    row.cell(f"Responsible: {x.responsibleAgent}")
-                    if x.responsibleAgent
-                    else row.cell("N/A")
-                )
+                row.cell(f"{start_time}")
+                row.cell(f"{x.hasEndDatetime if x.hasEndDatetime else x.hasEndDatetime}")
+                row.cell(f"R{x.responsibleAgent if x.responsibleAgent else 'N/A'}")
 
                 if x.usesAgriculturalMachinery:
                     machinery_ids = ", ".join(

--- a/app/utils/farm_calendar_report.py
+++ b/app/utils/farm_calendar_report.py
@@ -70,13 +70,13 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData) -> EX:
             row = table.row()
             row.style = style
             pdf.set_font("FreeSerif", "B", 10)
-            row.cell("Title");
-            row.cell("Details");
-            row.cell("Start");
+            row.cell("Title")
+            row.cell("Details")
+            row.cell("Start")
             row.cell("End")
-            row.cell("Responsible Agent");
-            row.cell("Type");
-            row.cell("Machinery IDs");
+            row.cell("Responsible Agent")
+            row.cell("Type")
+            row.cell("Machinery IDs")
             row.cell("Operated On")
             pdf.set_font("FreeSerif", "", 9)
             style = FontFace(fill_color=(255, 255, 240))
@@ -84,7 +84,7 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData) -> EX:
                 row = table.row()
                 row.style = style
 
-                row.cell(operation.title);
+                row.cell(operation.title)
                 row.cell(operation.details)
                 row.cell(
                     f"{operation.hasStartDatetime if operation.hasStartDatetime else 'N/A'}",
@@ -129,14 +129,14 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData) -> EX:
             row = table.row()
             row.style = style
             pdf.set_font("FreeSerif", "B", 10)
-            row.cell("Value");
-            row.cell("Value unit");
+            row.cell("Value")
+            row.cell("Value unit")
             row.cell("Property")
-            row.cell("Observed Property");
-            row.cell("Details");
+            row.cell("Observed Property")
+            row.cell("Details")
             row.cell("Start")
-            row.cell("End");
-            row.cell("Responsible Agent");
+            row.cell("End")
+            row.cell("Responsible Agent")
             row.cell("Machinery IDs")
             pdf.set_font("FreeSerif", "", 9)
             for x in calendar_data.observations:
@@ -290,6 +290,7 @@ def process_farm_calendar_data(
                 activity_type_info=observation_type_name,
                 observations=observations,
                 farm_activities=operations,
+                materials=materials
             )
         else:
             dt = json.load(data.file)
@@ -297,6 +298,7 @@ def process_farm_calendar_data(
                 activity_type_info=observation_type_name,
                 observations=dt["observations"],
                 farm_activities=dt["operations"],
+                materials=dt["materials"],
             )
 
         pdf = create_farm_calendar_pdf(calendar_data)

--- a/app/utils/farm_calendar_report.py
+++ b/app/utils/farm_calendar_report.py
@@ -76,7 +76,7 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData) -> EX:
                 f"Start",
             )
             row.cell("End")
-            row.cell("Responsible")
+            row.cell("Responsible Agent")
             row.cell("Type")
             row.cell("Machinery IDs")
             pdf.set_font("FreeSerif", "", 9)
@@ -142,7 +142,7 @@ def create_farm_calendar_pdf(calendar_data: FarmCalendarData) -> EX:
             row.cell("Details")
             row.cell("Start")
             row.cell("End")
-            row.cell("Responsible")
+            row.cell("Responsible Agent")
             row.cell("Machinery IDs")
             pdf.set_font("FreeSerif", "", 9)
 

--- a/app/utils/farm_calendar_report.py
+++ b/app/utils/farm_calendar_report.py
@@ -185,7 +185,7 @@ def process_farm_calendar_data(
             )
 
             if not farm_activity_type_info:
-                raise HTTPException(status_code=400, detail="Activity Type API failed.")
+                return
 
             del params["name"]
             params["activity_type"] = farm_activity_type_info[0]["@id"].split(":")[3]
@@ -196,19 +196,11 @@ def process_farm_calendar_data(
                 params=params,
             )
 
-            if not observations:
-                raise HTTPException(status_code=400, detail="Observations are empty.")
-
             farm_activities = make_get_request(
                 url=f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["activities"]}',
                 token=token,
                 params=params,
             )
-
-            if not farm_activities:
-                raise HTTPException(
-                    status_code=400, detail="Farm Activities are empty."
-                )
 
             calendar_data = FarmCalendarData(
                 activity_type_info=observation_type_name,

--- a/app/utils/irrigation_report.py
+++ b/app/utils/irrigation_report.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-from typing import Union, Optional
 
 from fastapi import HTTPException
 
@@ -125,15 +124,10 @@ def process_irrigation_data(data, token: dict[str, str], pdf_file_name: str) -> 
             params=params,
         )
 
-        if not json_data:
-            raise HTTPException(status_code=400, detail="No Irrigation data found.")
     else:
         json_data = json.load(data.file)
 
     operations = parse_irrigation_operations(json_data)
-
-    if not operations:
-        return
 
     try:
         pdf = create_pdf_from_operations(operations)

--- a/app/utils/irrigation_report.py
+++ b/app/utils/irrigation_report.py
@@ -5,7 +5,7 @@ import os
 from fastapi import HTTPException
 
 from core import settings
-from utils import EX, add_fonts
+from utils import EX, add_fonts, decode_dates_filters
 from schemas.irrigation import *
 from utils.json_handler import make_get_request
 
@@ -111,13 +111,15 @@ def create_pdf_from_operations(operations: List[IrrigationOperation]):
     return pdf
 
 
-def process_irrigation_data(data, token: dict[str, str], pdf_file_name: str) -> None:
+def process_irrigation_data(data, token: dict[str, str], pdf_file_name: str, from_date: datetime.date = None,
+                            to_date: datetime.date = None) -> None:
     """
     Process irrigation data and generate PDF report
     """
 
     if not data:
         params = {"format": "json"}
+        decode_dates_filters(params, from_date, to_date)
         json_data = make_get_request(
             url=f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["irrigations"]}',
             token=token,

--- a/app/utils/json_handler.py
+++ b/app/utils/json_handler.py
@@ -3,13 +3,15 @@ from fastapi import HTTPException
 from core import settings
 import requests
 from typing import Dict, Optional, Union
+import logging
 
+logger = logging.getLogger(__name__)
 
 def make_get_request(
     url: str,
     params: Optional[Dict[str, Union[str, int, float]]] = None,
     token: Optional[Dict[str, str]] = None,
-) -> Union[dict, str]:
+) -> Union[dict, str] | None:
     """
     Makes a GET request with custom parameters and headers.
 
@@ -51,5 +53,6 @@ def make_get_request(
 
         return response.json()
 
-    except Exception as ee:
-        raise HTTPException(status_code=400, detail="Gatekeeper API returned an error.")
+    except Exception as e:
+        logger.info(f"Gatekeeper API returned an error. {e}")
+        return None

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -49,9 +49,9 @@ def decode_dates_filters(params: dict, from_date: datetime.date =  None, to_date
     try:
         if from_date:
             from_date = from_date.strftime("%Y-%m-%d")
-            params['from_date'] = from_date
+            params['fromDate'] = from_date
         if to_date:
-            params['to_date'] = to_date.strftime("%Y-%m-%d")
+            params['toDate'] = to_date.strftime("%Y-%m-%d")
     except Exception as e:
         logger.info(f"Error in parsing date: {e}. Request will be sent without date filters.")
 

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -5,6 +5,10 @@ import os
 import jwt
 from fpdf import FPDF
 
+from core import settings
+from utils.json_handler import make_get_request
+from geopy.geocoders import Nominatim
+
 logger = logging.Logger("utils")
 
 def add_fonts(pdf):
@@ -50,3 +54,34 @@ def decode_dates_filters(params: dict, from_date: datetime.date =  None, to_date
             params['to_date'] = to_date.strftime("%Y-%m-%d")
     except Exception as e:
         logger.info(f"Error in parsing date: {e}. Request will be sent without date filters.")
+
+
+def get_parcel_info(parcel_id: str, token: dict, geolocator: Nominatim):
+    farm_parcel_info = make_get_request(
+        url=f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["parcel"]}{parcel_id}/',
+        token=token,
+        params={"format": "json"}
+    )
+    location = farm_parcel_info.get("location")
+    address = ''
+    farm = ''
+    if location:
+        coordinates = f"{location.get('lat')}, {location.get('long')}"
+        l_info = geolocator.reverse(coordinates)
+        address_details = l_info.raw.get('address', {})
+        city = address_details.get('city')
+        country = address_details.get("country")
+        postcode = address_details.get('postcode')
+        address = f"Country: {country} | City: {city} | Postcode: {postcode}"
+
+    farm_id = farm_parcel_info.get("farm").get("@id", "N/A").split(":")[-1]
+    if farm_id:
+        farm_info = make_get_request(
+            url=f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["farm"]}{farm_id}/',
+            token=token,
+            params={"format": "json"}
+        )
+
+        farm = f"Name: {farm_info.get('name', '')} | Municipality: {farm_info.get('address',{}).get('municipality', '')}"
+    return address, farm
+

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -1,8 +1,11 @@
+import datetime
+import logging
 import os
 
 import jwt
 from fpdf import FPDF
 
+logger = logging.Logger("utils")
 
 def add_fonts(pdf):
     fonts_folder_path = os.path.join(
@@ -37,3 +40,13 @@ def decode_jwt_token(token: str) -> dict:
     """
     decoded = jwt.decode(token, options={"verify_signature": False})
     return decoded
+
+def decode_dates_filters(params: dict, from_date: datetime.date =  None, to_date: datetime.date = None):
+    try:
+        if from_date:
+            from_date = from_date.strftime("%Y-%m-%d")
+            params['from_date'] = from_date
+        if to_date:
+            params['to_date'] = to_date.strftime("%Y-%m-%d")
+    except Exception as e:
+        logger.info(f"Error in parsing date: {e}. Request will be sent without date filters.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ python-multipart==0.0.9 # For uploading files (.csv, .xlss ...)
 SQLAlchemy==2.0.31
 pydantic==2.8.2
 starlette==0.37.2
+geopy==2.4.1
 
 fpdf2==2.7.9
 PyLD==2.0.4


### PR DESCRIPTION
Heading updated with:
Compost Location - taken from Farm/Parcel details
Starting date
Initial materials

Added operation_id reporting generation
Added from_date and to_date filters on reporting APIs

Refactored table view (use pdf.table except of classic pdf cells).
Updated title of the document with new logic. Font and letters on PDF changed to be more readable to human.

Created issue https://github.com/agstack/OpenAgri-ReportingService/issues/42 to use this table logic on other API calls.

Added handler for statuses !=200 on login and updated endpoint for get PDF with '/' at the end.

Additional update:
-> When something errors, make empty PDF (if data can not be used) avoid non-creation of PDF because of dashboard logic