### PR TITLE
44 issue

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
         "activity_types": "/FarmCalendarActivityTypes/",
         "observations": "/Observations/",
         "operations": "/CompostOperations/",
+        "turning_operations": "/CompostTurningOperations/",
         "activities": "/FarmCalendarActivities/",
         "parcel": "/FarmParcels/",
         "animals": "/FarmAnimals/",

--- a/app/schemas/compost.py
+++ b/app/schemas/compost.py
@@ -8,6 +8,9 @@ class QuantityValue(BaseModel):
     unit: str = ""
     numericValue: float = 0.0
 
+class QuantityValueIrrigation(BaseModel):
+    unit: str = ""
+    numericValue: float = 0.0
 
 class CompostMaterial(BaseModel):
     type: str = Field(alias="@type")
@@ -66,3 +69,4 @@ class Operation(BaseModel):
 class AddRawMaterialOperation(Operation):
     usesAgriculturalMachinery: List = []
     hasCompostMaterial: List[CompostMaterial] = []
+    hasAppliedAmount: Optional[QuantityValueIrrigation] = None

--- a/app/utils/farm_calendar_report.py
+++ b/app/utils/farm_calendar_report.py
@@ -379,6 +379,7 @@ def process_farm_calendar_data(
                             token=token,
                             params=params
                         )
+                        # In case endpoint does not return empty array (fails)
                         compost_turning_ops = compost_turning_ops if compost_turning_ops else []
                         irrigation_ops = irrigation_ops if irrigation_ops else []
                         materials = materials_partials + compost_turning_ops + irrigation_ops

--- a/app/utils/farm_calendar_report.py
+++ b/app/utils/farm_calendar_report.py
@@ -344,45 +344,44 @@ def process_farm_calendar_data(
                                 params=params
                             )
                             calendar_activity_type = farm_activity_type_info['name']
-                    if operations[0]['hasMeasurement']:
-                        obs_op_url = (
-                            f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["operations"]}{operation_id}{settings.REPORTING_FARMCALENDAR_URLS["observations"]}')
 
-                        print(obs_op_url)
-                        observations = make_get_request(
-                            url=obs_op_url,
-                            token=token,
-                            params=params,
-                        )
+                    obs_op_url = (
+                        f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["operations"]}{operation_id}{settings.REPORTING_FARMCALENDAR_URLS["observations"]}')
 
-                    if operations[0]['hasNestedOperation']:
-                        material_url = (
-                            f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["operations"]}{operation_id}{settings.REPORTING_FARMCALENDAR_URLS["materials"]}')
-                        materials_partials = make_get_request(
-                            url=material_url,
-                            token=token,
-                            params=params
-                        )
+                    observations = make_get_request(
+                        url=obs_op_url,
+                        token=token,
+                        params=params,
+                    )
 
-                        comp_irrigation_url = (
-                            f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["operations"]}{operation_id}{settings.REPORTING_FARMCALENDAR_URLS["irrigations"]}')
-                        irrigation_ops =  make_get_request(
-                            url=comp_irrigation_url,
-                            token=token,
-                            params=params
-                        )
 
-                        comp_turn_url = (
-                            f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["operations"]}{operation_id}{settings.REPORTING_FARMCALENDAR_URLS["turning_operations"]}')
-                        compost_turning_ops = make_get_request(
-                            url=comp_turn_url,
-                            token=token,
-                            params=params
-                        )
-                        # In case endpoint does not return empty array (fails)
-                        compost_turning_ops = compost_turning_ops if compost_turning_ops else []
-                        irrigation_ops = irrigation_ops if irrigation_ops else []
-                        materials = materials_partials + compost_turning_ops + irrigation_ops
+                    material_url = (
+                        f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["operations"]}{operation_id}{settings.REPORTING_FARMCALENDAR_URLS["materials"]}')
+                    materials_partials = make_get_request(
+                        url=material_url,
+                        token=token,
+                        params=params
+                    )
+
+                    comp_irrigation_url = (
+                        f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["operations"]}{operation_id}{settings.REPORTING_FARMCALENDAR_URLS["irrigations"]}')
+                    irrigation_ops =  make_get_request(
+                        url=comp_irrigation_url,
+                        token=token,
+                        params=params
+                    )
+
+                    comp_turn_url = (
+                        f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["operations"]}{operation_id}{settings.REPORTING_FARMCALENDAR_URLS["turning_operations"]}')
+                    compost_turning_ops = make_get_request(
+                        url=comp_turn_url,
+                        token=token,
+                        params=params
+                    )
+                    # In case endpoint does not return empty array (fails)
+                    compost_turning_ops = compost_turning_ops if compost_turning_ops else []
+                    irrigation_ops = irrigation_ops if irrigation_ops else []
+                    materials = materials_partials + compost_turning_ops + irrigation_ops
 
 
 


### PR DESCRIPTION
Related issue:
https://github.com/agstack/OpenAgri-ReportingService/issues/44

- corporate /IrrigationOperations/ and /CompostTurningOperations/ in PDF SIP5 report
- next to AddRawMaterialOperations in PDF report incorporate above Operations change retrieval of Observations (except of loop over hasMeasurements and get by ID, use /CompostOperations/id/Observations/)


New example:
[5d77cc62-b3cf-4057-9c69-c1eff9774fb4.pdf](https://github.com/user-attachments/files/22088744/5d77cc62-b3cf-4057-9c69-c1eff9774fb4.pdf)
