### PR TITLE
Feature/standalone report

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,105 @@ Response is uuid of generated PDF file.
 
 Response is uuid of generated PDF file.
 
+<h3>POST</h3>
+
+```
+/api/v1/openagri-report/standalone-observation-report/
+```
+
+This endpoint is intended for environments where **no Farm Calendar service is available**.
+Unlike the other endpoints, **no authentication is required** (no Bearer token), no Farm
+Calendar lookups are performed, and parcel/farm information must be supplied manually
+as multipart form fields. The observation payload must be a **pure JSON-LD observation
+array** (top-level `[ ... ]`), not the `{"@graph": [...]}` envelope used by the other
+endpoints.
+
+The generated PDF is stored under a shared `standalone/` folder (not scoped per user),
+and is retrieved via a dedicated unauthenticated GET endpoint (see below).
+
+## Request Params
+
+### data
+- **Type**: `UploadFile` (required)
+- **Description**: A JSON file whose top-level structure is an array of JSON-LD
+  observation objects (e.g. `[ {"@type": "Observation", ...}, ... ]`). Each item is
+  validated against the `CropObservation` schema.
+
+### title
+- **Type**: `str`
+- **Description**: Report title shown on the PDF (default: `"Observation Report"`).
+
+### from_date
+- **Type**: `date`
+- **Description**: Optional reporting period start; only used in the header.
+
+### to_date
+- **Type**: `date`
+- **Description**: Optional reporting period end; only used in the header.
+
+### parcel_address
+- **Type**: `str`
+- **Description**: Free-text parcel address shown in the Farm Details section.
+
+### parcel_identifier
+- **Type**: `str`
+- **Description**: Parcel identifier shown in the Farm Details section.
+
+### parcel_area
+- **Type**: `float`
+- **Description**: Parcel area in m². Optional.
+
+### parcel_lat
+- **Type**: `float`
+- **Description**: Parcel latitude. When both `parcel_lat` and `parcel_lng` are
+  provided, a Sentinel-2 satellite tile is embedded in the report (network permitting).
+
+### parcel_lng
+- **Type**: `float`
+- **Description**: Parcel longitude. See `parcel_lat`.
+
+### farm_name / farm_municipality / farm_administrator / farm_vat_id / farm_contact_person / farm_description
+- **Type**: `str`
+- **Description**: Manual farm fields displayed in the Farm Details section.
+
+## Response
+
+Response is uuid of generated PDF file.
+
+<h3>GET</h3>
+
+```
+/api/v1/openagri-report/standalone-observation-report/{report_id}/
+```
+
+Retrieve a previously generated standalone-observation PDF. **No authentication
+required.** Returns the PDF with status 200 when ready, or 202 while generation is
+still in progress.
+
+### report_id
+- **Type**: `uuid str`
+- **Description**: UUID returned by the standalone-observation POST.
+
+<h3> Example usage </h3>
+
+```shell
+# No --token needed for the standalone-observation endpoint:
+python3 scripts/report_client.py --type standalone-observation \
+    --file scripts/standalone_observation_data.json \
+    --title "Compost B-42 Observations" \
+    --from-date 2025-10-10 --to-date 2025-10-12 \
+    --parcel-address "Country: GR | City: Athens | Postcode: 10000" \
+    --parcel-identifier "PARCEL-B42" \
+    --parcel-area 12500 \
+    --parcel-lat 37.9838 --parcel-lng 23.7275 \
+    --farm-name "Demo Farm" \
+    --farm-municipality "Athens" \
+    --farm-administrator "John Doe" \
+    --farm-vat-id "EL123456789" \
+    --farm-contact-person "Jane Roe" \
+    --farm-description "Demonstration compost farm."
+```
+
 <h2>Pytest</h2>
 Pytest can be run on the same machine the service has been deployed to by moving into the app dir and running:
 
@@ -290,7 +389,7 @@ This will run all tests and return success values for each api tested in the ter
 <h3>These tests will NOT result in generated .pdf files.</h3>
 
 ## Working examples
-You can find working examples for animal, irrigation as well as compost reports generation in the following pages:
+You can find working examples for animal, irrigation, compost, pesticides, fertilization and standalone-observation reports generation in the following pages:
 
 [Script](scripts/report_client.py)
 

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -253,6 +253,7 @@ def retrieve_standalone_observation_pdf(report_id: str):
     """
     file_path = f"{settings.PDF_DIRECTORY}standalone/{report_id}.pdf"
 
+
     if not os.path.exists(file_path):
         raise HTTPException(
             status_code=202,

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -6,6 +6,8 @@ from typing import Optional
 from fastapi import (
     APIRouter,
     Depends,
+    File,
+    Form,
     HTTPException,
     UploadFile,
     BackgroundTasks,
@@ -14,11 +16,12 @@ from pydantic import UUID4
 
 from api import deps
 from core import settings
-from schemas import PDF
+from schemas import PDF, ManualFarmInfo, ManualParcelInfo
 from utils import decode_jwt_token
 from utils.animals_report import process_animal_data
 from utils.farm_calendar_report import process_farm_calendar_data
 from utils.irrig_fert_pest_report import process_irrigation_fertilization_data
+from utils.standalone_observation_report import process_standalone_observation_data
 from fastapi.responses import FileResponse
 
 router = APIRouter()
@@ -237,6 +240,87 @@ async def generate_fertilization_report(
         parcel_id=parcel_id,
         irrigation_flag=False,
         fertilization_flag=True
+    )
+
+    return PDF(uuid=uuid_v4)
+
+
+@router.get("/standalone-observation-report/{report_id}/", response_class=FileResponse)
+def retrieve_standalone_observation_pdf(report_id: str):
+    """
+    Retrieve a standalone-observation PDF. No authentication required —
+    matches the no-auth POST endpoint.
+    """
+    file_path = f"{settings.PDF_DIRECTORY}standalone/{report_id}.pdf"
+
+    if not os.path.exists(file_path):
+        raise HTTPException(
+            status_code=202,
+            detail=f"PDF uuid {report_id} is being generated. Please be patient and try again in couple of seconds.",
+        )
+
+    return FileResponse(
+        path=file_path, media_type="application/pdf", filename=f"{report_id}"
+    )
+
+
+@router.post("/standalone-observation-report/", response_model=PDF)
+async def generate_standalone_observation_report(
+    background_tasks: BackgroundTasks,
+    data: UploadFile = File(..., description="JSON file containing a pure JSON-LD observation array"),
+    title: str = Form("Observation Report"),
+    from_date: Optional[datetime.date] = Form(None),
+    to_date: Optional[datetime.date] = Form(None),
+    parcel_address: str = Form(""),
+    parcel_identifier: str = Form(""),
+    parcel_area: float = Form(0.0),
+    parcel_lat: Optional[float] = Form(None),
+    parcel_lng: Optional[float] = Form(None),
+    farm_name: str = Form(""),
+    farm_municipality: str = Form(""),
+    farm_administrator: str = Form(""),
+    farm_vat_id: str = Form(""),
+    farm_contact_person: str = Form(""),
+    farm_description: str = Form(""),
+):
+    """
+    Generates an Observation Report PDF from a pure JSON-LD observation array.
+
+    Unlike the other endpoints, no Farm Calendar lookups happen here and no
+    authentication is required. Parcel and farm information must be supplied
+    manually as form fields, and the observation data must be uploaded as a
+    top-level JSON array (e.g. `[ {"@type": "Observation", ...}, ... ]`).
+    """
+    uuid_v4 = str(uuid.uuid4())
+    uuid_of_pdf = f"standalone/{uuid_v4}"
+
+    parcel = ManualParcelInfo(
+        address=parcel_address,
+        identifier=parcel_identifier,
+        area=parcel_area,
+        lat=parcel_lat,
+        lng=parcel_lng,
+    )
+    farm = ManualFarmInfo(
+        name=farm_name,
+        municipality=farm_municipality,
+        administrator=farm_administrator,
+        vatID=farm_vat_id,
+        contactPerson=farm_contact_person,
+        description=farm_description,
+    )
+
+    file_bytes = data.file.read()
+
+    background_tasks.add_task(
+        process_standalone_observation_data,
+        data=file_bytes,
+        pdf_file_name=uuid_of_pdf,
+        parcel=parcel,
+        farm=farm,
+        title=title,
+        from_date=from_date,
+        to_date=to_date,
     )
 
     return PDF(uuid=uuid_v4)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -4,3 +4,4 @@ from .user import *
 from .irrigation import *
 from .compost import *
 from .animals import *
+from .standalone_observation import *

--- a/app/schemas/compost.py
+++ b/app/schemas/compost.py
@@ -26,7 +26,7 @@ class ActivityType(BaseModel):
 
 class HasResult(BaseModel):
     type: str = Field(alias="@type")
-    id: str = Field(alias="@id")
+    id: Optional[str] = Field(alias="@id", default=None)
     unit: Optional[str] = None
     hasValue: Optional[str] = None
 
@@ -34,7 +34,7 @@ class CropObservation(BaseModel):
     """Model for observations"""
 
     type: str = Field(alias="@type")
-    id: str = Field(alias="@id")
+    id: Optional[str] = Field(alias="@id", default=None)
     activityType: Optional[dict] = None
     title: Optional[str] = ""
     details: Optional[str] = ""

--- a/app/schemas/standalone_observation.py
+++ b/app/schemas/standalone_observation.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class ManualParcelInfo(BaseModel):
+    address: str = ""
+    identifier: str = ""
+    area: float = 0.0
+    lat: Optional[float] = None
+    lng: Optional[float] = None
+
+
+class ManualFarmInfo(BaseModel):
+    name: str = ""
+    municipality: str = ""
+    administrator: str = ""
+    vatID: str = ""
+    contactPerson: str = ""
+    description: str = ""

--- a/app/utils/standalone_observation_report.py
+++ b/app/utils/standalone_observation_report.py
@@ -1,0 +1,215 @@
+import datetime
+import io
+import json
+import logging
+import os
+from typing import List, Optional
+
+from fastapi import HTTPException
+from fpdf.enums import VAlign
+
+from core import settings
+from schemas import CropObservation, ManualFarmInfo, ManualParcelInfo
+from utils import EX, add_fonts
+from utils.satellite_image_get import SatelliteImageException, fetch_wms_image
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def _parse_observations(raw) -> List[CropObservation]:
+    if not isinstance(raw, list):
+        raise HTTPException(
+            status_code=400,
+            detail="Observations payload must be a JSON array of observation JSON-LD objects.",
+        )
+    try:
+        return [CropObservation.model_validate(item) for item in raw]
+    except Exception as e:
+        logger.error(f"Error parsing standalone observations: {e}")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Reporting service failed during observation validation. {e}",
+        )
+
+
+def _render_farm_details(
+    pdf: EX,
+    parcel: ManualParcelInfo,
+    farm: ManualFarmInfo,
+    from_date: Optional[datetime.date],
+    to_date: Optional[datetime.date],
+):
+    today = datetime.datetime.now().strftime("%d/%m/%Y")
+    from_date_local = from_date.strftime("%Y-%m-%d") if from_date else today
+    to_date_local = to_date.strftime("%Y-%m-%d") if to_date else ""
+
+    pdf.set_font("FreeSerif", "B", 15)
+    pdf.set_x((pdf.w / 4) - 30)
+    pdf.cell(30, 8, "1. Farm Details", align="L")
+    pdf.multi_cell(0, 8, "", ln=True, fill=False)
+
+    pdf.set_font("FreeSerif", "B", 10)
+    pdf.cell(40, 8, "Reporting Period")
+    pdf.set_font("FreeSerif", "", 10)
+    pdf.multi_cell(0, 8, f"{from_date_local} / {to_date_local}", ln=True, fill=True)
+
+    rows = [
+        ("Parcel Location:", parcel.address),
+        ("Parcel Identifier:", parcel.identifier),
+        ("Parcel Area (m2):", f"{parcel.area}" if parcel.area else ""),
+        ("Farm Name:", farm.name),
+        ("Municipality:", farm.municipality),
+        ("Administrator:", farm.administrator),
+        ("Contact Person:", farm.contactPerson),
+        ("Farm VAT:", farm.vatID),
+        ("Farm Description:", farm.description),
+    ]
+    for label, value in rows:
+        pdf.set_font("FreeSerif", "B", 10)
+        pdf.cell(40, 8, label)
+        pdf.set_font("FreeSerif", "", 10)
+        pdf.multi_cell(0, 8, value or "", ln=True, fill=True)
+
+    if parcel.lat is not None and parcel.lng is not None:
+        try:
+            image_bytes = fetch_wms_image(parcel.lat, parcel.lng)
+            image_file = io.BytesIO(image_bytes)
+            pdf.ln(2)
+            x_start = (pdf.w - 100) / 2
+            pdf.set_x(x_start)
+            pdf.image(image_file, type="png", w=100)
+        except SatelliteImageException:
+            logger.info("Satellite image issue happened, continue without image.")
+
+
+def _render_observation_table(pdf: EX, observations: List[CropObservation]):
+    if not observations:
+        pdf.ln(4)
+        pdf.set_font("FreeSerif", "", 10)
+        pdf.cell(0, 8, "No observations provided.", ln=True)
+        return
+
+    observations.sort(
+        key=lambda o: o.hasStartDatetime
+        or o.phenomenonTime
+        or datetime.datetime.min
+    )
+
+    pdf.add_page()
+    pdf.set_font("FreeSerif", "B", 15)
+    pdf.set_x((pdf.w / 4) - 30)
+    pdf.cell(30, 8, "2. Observations", align="L", ln=True)
+    pdf.ln(4)
+
+    pdf.set_fill_color(0, 255, 255)
+    with pdf.table(text_align="CENTER", padding=0.5, v_align=VAlign.M) as table:
+        row = table.row()
+        pdf.set_font("FreeSerif", "B", 10)
+        row.cell("Start - End")
+        row.cell("Observed Property")
+        row.cell("Value")
+        row.cell("Unit")
+        row.cell("Responsible Agent")
+        row.cell("Details")
+        pdf.set_font("FreeSerif", "", 9)
+        pdf.set_fill_color(255, 255, 240)
+        for obs in observations:
+            row = table.row()
+            start = obs.hasStartDatetime or obs.phenomenonTime
+            end = obs.hasEndDatetime
+            start_str = start.strftime("%d/%m/%Y") if start else ""
+            end_str = end.strftime("%d/%m/%Y") if end else ""
+            row.cell(f"{start_str} - {end_str}".strip(" -"))
+            row.cell(obs.observedProperty or "")
+            value = obs.hasResult.hasValue if obs.hasResult and obs.hasResult.hasValue else ""
+            unit = obs.hasResult.unit if obs.hasResult and obs.hasResult.unit else ""
+            row.cell(str(value))
+            row.cell(unit)
+            row.cell(obs.responsibleAgent or "")
+            row.cell(obs.details or "")
+
+
+def create_standalone_observation_pdf(
+    observations: List[CropObservation],
+    parcel: ManualParcelInfo,
+    farm: ManualFarmInfo,
+    title: str,
+    from_date: Optional[datetime.date],
+    to_date: Optional[datetime.date],
+) -> EX:
+    pdf = EX()
+    add_fonts(pdf)
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.add_page()
+
+    EX.ln(pdf)
+
+    pdf.set_font("FreeSerif", "B", 14)
+    pdf.cell(0, 10, title, ln=True, align="C")
+    pdf.set_font("FreeSerif", style="", size=9)
+    pdf.cell(
+        0,
+        7,
+        f"Data Generated - {datetime.datetime.now().strftime('%d/%m/%Y')}",
+        ln=True,
+        align="C",
+    )
+    pdf.ln(5)
+
+    y_position = pdf.get_y()
+    line_end_x = pdf.w - pdf.l_margin - pdf.r_margin
+    pdf.line(pdf.l_margin, y_position, line_end_x, y_position)
+    pdf.ln(5)
+
+    pdf.set_fill_color(240, 240, 240)
+    _render_farm_details(pdf, parcel, farm, from_date, to_date)
+    _render_observation_table(pdf, observations)
+    pdf.ln(10)
+    return pdf
+
+
+def process_standalone_observation_data(
+    data: bytes,
+    pdf_file_name: str,
+    parcel: ManualParcelInfo,
+    farm: ManualFarmInfo,
+    title: str = "Observation Report",
+    from_date: Optional[datetime.date] = None,
+    to_date: Optional[datetime.date] = None,
+) -> None:
+    try:
+        if not data:
+            raise HTTPException(
+                status_code=400,
+                detail="Observation JSON-LD payload is required.",
+            )
+
+        try:
+            payload = json.loads(data)
+        except json.JSONDecodeError as e:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid JSON payload for observations: {e}",
+            )
+
+        observations = _parse_observations(payload)
+
+        pdf = create_standalone_observation_pdf(
+            observations=observations,
+            parcel=parcel,
+            farm=farm,
+            title=title,
+            from_date=from_date,
+            to_date=to_date,
+        )
+        pdf_dir = f"{settings.PDF_DIRECTORY}{pdf_file_name}"
+        os.makedirs(os.path.dirname(f"{pdf_dir}.pdf"), exist_ok=True)
+        pdf.output(f"{pdf_dir}.pdf")
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Error processing standalone observation data: {str(e)}",
+        )

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -1,4 +1,4 @@
-This command-line script (report_client.py) provides a simple way to interact with the Reporting service. It allows you to request the generation of three different types of reports (animal, irrigation, or compost) by uploading a corresponding JSON data file.
+This command-line script (report_client.py) provides a simple way to interact with the Reporting service. It allows you to request the generation of any supported report type (animal, irrigation, compost, pesticides, fertilization, standalone-observation) by uploading a corresponding JSON data file.
 
 The script handles the entire workflow:
 
@@ -31,10 +31,11 @@ Command-Line Arguments
 
 | Argument | Required | Description |
 |----------|----------|----|
-| --type   | Yes      | The type of report to generate. Must be one of animal, irrigation, or compost.  |
-| --token  | Yes      | Your personal authentication bearer token for the service. |
+| --type   | Yes      | The type of report to generate. One of animal, irrigation, compost, pesticides, fertilization, standalone-observation.  |
+| --token  | Conditional | Your personal authentication bearer token. Required for **all** report types **except** standalone-observation, which is fully unauthenticated. |
 | --file   | Yes      | The relative or absolute path to the JSON file containing the data for the report. |
 | --url    | No       | The base URL of the reporting service. If not provided, it defaults to http://127.0.0.1:8009. |
+| --title, --from-date, --to-date, --parcel-*, --farm-* | No | Manual parcel/farm fields, used only by `--type standalone-observation`. See the standalone section below. |
 
 Example Commands
 Animal Report
@@ -49,11 +50,45 @@ Compost Report (with a custom URL)
 ```
 python3 report_client.py --type compost --token "your-auth-token-here" --file "compost.json" --url "http://api.myfarm.com"
 ```
+
+Standalone Observation Report
+
+This endpoint is intended for environments where no Farm Calendar service is available
+and **no authentication is required** (no token needed). Parcel and farm information
+are NOT looked up from external services — they must be supplied manually as
+command-line flags. The JSON file must be a **pure JSON-LD observation array**
+(top-level `[ ... ]`), not the `{"@graph": [...]}` envelope used by the other endpoints.
+See `standalone_observation_data.json` for an example.
+
+```
+python3 report_client.py --type standalone-observation \
+    --file "./standalone_observation_data.json" \
+    --title "Compost B-42 Observations" \
+    --from-date 2025-10-10 --to-date 2025-10-12 \
+    --parcel-address "Country: GR | City: Athens | Postcode: 10000" \
+    --parcel-identifier "PARCEL-B42" \
+    --parcel-area 12500 \
+    --parcel-lat 37.9838 --parcel-lng 23.7275 \
+    --farm-name "Demo Farm" \
+    --farm-municipality "Athens" \
+    --farm-administrator "John Doe" \
+    --farm-vat-id "EL123456789" \
+    --farm-contact-person "Jane Roe" \
+    --farm-description "Demonstration compost farm."
+```
+
+When `--parcel-lat` and `--parcel-lng` are both provided, the report will also
+include a Sentinel-2 satellite tile centered on those coordinates (network
+permitting; the report still renders without it).
+
 How It Works
 
-    Generate Report: The script sends a POST request to the appropriate endpoint (e.g., /api/v1/openagri-report/animal-report/) with your token and JSON file. The server accepts the request and returns a unique uuid for the report job.
+    Generate Report: The script sends a POST request to the appropriate endpoint (e.g., /api/v1/openagri-report/animal-report/) with your token (when required) and JSON file. The server accepts the request and returns a unique uuid for the report job.
 
-    Download PDF: The script then enters a loop, sending GET requests to the retrieval endpoint (e.g., /api/v1/openagri-report/<uuid>/).
+    Download PDF: The script then enters a loop, sending GET requests to the retrieval endpoint:
+
+        - For all auth'd report types: /api/v1/openagri-report/<uuid>/ (with Bearer token).
+        - For --type standalone-observation: /api/v1/openagri-report/standalone-observation-report/<uuid>/ (no Authorization header — the endpoint is intentionally unauthenticated and serves PDFs from a shared `standalone/` folder rather than a per-user folder).
 
         If the server responds with status 202 Accepted, it means the PDF is still being created, and the script waits a few seconds before trying again.
 

--- a/scripts/report_client.py
+++ b/scripts/report_client.py
@@ -17,19 +17,53 @@ RETRY_DELAY_SECONDS = 3
 # python report_client.py --type pesticides --token "your-long-auth-token-here" --file "path/to/pesticides_data.json"
 # python report_client.py --type fertilization --token "your-long-auth-token-here" --file "path/to/fertilization_data.json"
 # python report_client.py --type compost --token "your-long-auth-token-here" --file "compost.json" --url "http://localhost:5000"
+# standalone-observation does NOT require a token (auth is disabled for that endpoint):
+# python report_client.py --type standalone-observation \
+#     --file "standalone_observation_data.json" \
+#     --farm-name "Demo Farm" --farm-municipality "Athens" \
+#     --parcel-address "Country: GR | City: Athens | Postcode: 10000" \
+#     --parcel-lat 37.9838 --parcel-lng 23.7275
 
 
 # --- End Configuration ---
 
-def generate_report(report_type: str, base_url: str, token: str, json_file: str) -> str | None:
+# Form fields supported by the standalone-observation endpoint
+STANDALONE_FORM_FIELDS = (
+    "title",
+    "from_date",
+    "to_date",
+    "parcel_address",
+    "parcel_identifier",
+    "parcel_area",
+    "parcel_lat",
+    "parcel_lng",
+    "farm_name",
+    "farm_municipality",
+    "farm_administrator",
+    "farm_vat_id",
+    "farm_contact_person",
+    "farm_description",
+)
+
+
+def generate_report(
+    report_type: str,
+    base_url: str,
+    token: str | None,
+    json_file: str,
+    form_fields: dict | None = None,
+) -> str | None:
     """
     Calls the appropriate report endpoint and returns the report UUID.
 
     Args:
-        report_type: The type of report ('animal', 'irrigation', 'pesticides', 'fertilization', 'compost').
+        report_type: The type of report ('animal', 'irrigation', 'pesticides',
+            'fertilization', 'compost', 'standalone-observation').
         base_url: The base URL of the reporting service.
-        token: The authentication bearer token.
+        token: The authentication bearer token (None for standalone-observation).
         json_file: The path to the JSON data file to upload.
+        form_fields: Optional dict of multipart form fields (used by the
+            standalone-observation endpoint to pass manual parcel/farm data).
 
     Returns:
         The report UUID string if successful, otherwise None.
@@ -38,9 +72,7 @@ def generate_report(report_type: str, base_url: str, token: str, json_file: str)
     report_url = f"{base_url}/api/v1/openagri-report/{report_type}-report/"
     print(f"➡️  Attempting to generate '{report_type}' report from '{json_file}'...")
 
-    headers = {
-        "Authorization": f"Bearer {token}"
-    }
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
 
     try:
         with open(json_file, 'rb') as f:
@@ -48,7 +80,12 @@ def generate_report(report_type: str, base_url: str, token: str, json_file: str)
             files = {
                 "data": (os.path.basename(json_file), f, "application/json")
             }
-            response = requests.post(report_url, headers=headers, files=files)
+            response = requests.post(
+                report_url,
+                headers=headers,
+                files=files,
+                data=form_fields or None,
+            )
             response.raise_for_status()  # Raises an exception for 4XX/5XX errors
 
         response_data = response.json()
@@ -71,16 +108,23 @@ def generate_report(report_type: str, base_url: str, token: str, json_file: str)
         return None
 
 
-def download_pdf(report_uuid: str, base_url: str, token: str):
+def download_pdf(
+    report_uuid: str,
+    base_url: str,
+    token: str | None,
+    report_type: str,
+):
     """
     Polls the retrieval endpoint and downloads the generated PDF.
+    The standalone-observation report uses a dedicated unauthenticated GET path.
     """
     print(f"⏳ Attempting to download PDF for report ID: {report_uuid}...")
-    pdf_url = f"{base_url}/api/v1/openagri-report/{report_uuid}/"
-
-    headers = {
-        "Authorization": f"Bearer {token}"
-    }
+    if report_type == "standalone-observation":
+        pdf_url = f"{base_url}/api/v1/openagri-report/standalone-observation-report/{report_uuid}/"
+        headers = {}
+    else:
+        pdf_url = f"{base_url}/api/v1/openagri-report/{report_uuid}/"
+        headers = {"Authorization": f"Bearer {token}"} if token else {}
 
     for attempt in range(MAX_RETRIES):
         try:
@@ -124,13 +168,13 @@ def main():
     parser.add_argument(
         "--type",
         required=True,
-        choices=['animal', 'irrigation', 'compost', 'pesticides', 'fertilization'],
+        choices=['animal', 'irrigation', 'compost', 'pesticides', 'fertilization', 'standalone-observation'],
         help="The type of report to generate."
     )
     parser.add_argument(
         "--token",
-        required=True,
-        help="Your authentication bearer token."
+        default=None,
+        help="Your authentication bearer token. Required for all report types EXCEPT standalone-observation."
     )
     parser.add_argument(
         "--file",
@@ -143,11 +187,44 @@ def main():
         help="The base URL of the reporting service. (default: http://127.0.0.1:8009)"
     )
 
+    # Manual parcel/farm fields used only by the standalone-observation endpoint.
+    # All optional; sent as multipart form fields alongside the JSON file.
+    standalone_group = parser.add_argument_group(
+        "standalone-observation fields",
+        "Manual parcel/farm data for --type standalone-observation (no Farm Calendar lookup).",
+    )
+    standalone_group.add_argument("--title", default=None, help="Report title (default: 'Observation Report').")
+    standalone_group.add_argument("--from-date", default=None, help="Reporting period start (YYYY-MM-DD).")
+    standalone_group.add_argument("--to-date", default=None, help="Reporting period end (YYYY-MM-DD).")
+    standalone_group.add_argument("--parcel-address", default=None)
+    standalone_group.add_argument("--parcel-identifier", default=None)
+    standalone_group.add_argument("--parcel-area", default=None, help="Parcel area in m2.")
+    standalone_group.add_argument("--parcel-lat", default=None, help="Parcel latitude (enables satellite image).")
+    standalone_group.add_argument("--parcel-lng", default=None, help="Parcel longitude (enables satellite image).")
+    standalone_group.add_argument("--farm-name", default=None)
+    standalone_group.add_argument("--farm-municipality", default=None)
+    standalone_group.add_argument("--farm-administrator", default=None)
+    standalone_group.add_argument("--farm-vat-id", default=None)
+    standalone_group.add_argument("--farm-contact-person", default=None)
+    standalone_group.add_argument("--farm-description", default=None)
+
     args = parser.parse_args()
 
-    report_id = generate_report(args.type, args.url, args.token, args.file)
+    if args.type != "standalone-observation" and not args.token:
+        parser.error("--token is required for all report types except standalone-observation.")
+
+    form_fields = None
+    if args.type == "standalone-observation":
+        # argparse stores --foo-bar as foo_bar; the endpoint expects the same names
+        form_fields = {}
+        for field in STANDALONE_FORM_FIELDS:
+            value = getattr(args, field, None)
+            if value is not None and value != "":
+                form_fields[field] = value
+
+    report_id = generate_report(args.type, args.url, args.token, args.file, form_fields)
     if report_id:
-        download_pdf(report_id, args.url, args.token)
+        download_pdf(report_id, args.url, args.token, args.type)
 
 
 if __name__ == "__main__":

--- a/scripts/standalone_observation_data.json
+++ b/scripts/standalone_observation_data.json
@@ -1,0 +1,50 @@
+[
+  {
+    "@id": "urn:ngsi-ld:CropObservation:obs-temp-001",
+    "@type": "Observation",
+    "phenomenonTime": "2025-10-10T08:15:00Z",
+    "hasStartDatetime": "2025-10-10T08:15:00Z",
+    "hasEndDatetime": "2025-10-10T08:30:00Z",
+    "observedProperty": "temperature",
+    "responsibleAgent": "John Doe",
+    "details": "Core temperature reading on compost pile B-42.",
+    "hasResult": {
+      "@id": "urn:ngsi-ld:Property:result-temp-001",
+      "@type": "Property",
+      "hasValue": "62",
+      "unit": "CEL"
+    }
+  },
+  {
+    "@id": "urn:ngsi-ld:CropObservation:obs-moist-001",
+    "@type": "Observation",
+    "phenomenonTime": "2025-10-11T09:00:00Z",
+    "hasStartDatetime": "2025-10-11T09:00:00Z",
+    "hasEndDatetime": "2025-10-11T09:10:00Z",
+    "observedProperty": "moisture",
+    "responsibleAgent": "Jane Roe",
+    "details": "Moisture sensor reading at 30 cm depth.",
+    "hasResult": {
+      "@id": "urn:ngsi-ld:Property:result-moist-001",
+      "@type": "Property",
+      "hasValue": "55",
+      "unit": "P1"
+    }
+  },
+  {
+    "@id": "urn:ngsi-ld:CropObservation:obs-ph-001",
+    "@type": "Observation",
+    "phenomenonTime": "2025-10-12T10:00:00Z",
+    "hasStartDatetime": "2025-10-12T10:00:00Z",
+    "hasEndDatetime": "2025-10-12T10:05:00Z",
+    "observedProperty": "pH",
+    "responsibleAgent": "John Doe",
+    "details": "pH probe reading.",
+    "hasResult": {
+      "@id": "urn:ngsi-ld:Property:result-ph-001",
+      "@type": "Property",
+      "hasValue": "7.2",
+      "unit": "pH"
+    }
+  }
+]

--- a/scripts/standalone_observation_data.json
+++ b/scripts/standalone_observation_data.json
@@ -1,6 +1,5 @@
 [
   {
-    "@id": "urn:ngsi-ld:CropObservation:obs-temp-001",
     "@type": "Observation",
     "phenomenonTime": "2025-10-10T08:15:00Z",
     "hasStartDatetime": "2025-10-10T08:15:00Z",
@@ -16,7 +15,6 @@
     }
   },
   {
-    "@id": "urn:ngsi-ld:CropObservation:obs-moist-001",
     "@type": "Observation",
     "phenomenonTime": "2025-10-11T09:00:00Z",
     "hasStartDatetime": "2025-10-11T09:00:00Z",
@@ -32,7 +30,6 @@
     }
   },
   {
-    "@id": "urn:ngsi-ld:CropObservation:obs-ph-001",
     "@type": "Observation",
     "phenomenonTime": "2025-10-12T10:00:00Z",
     "hasStartDatetime": "2025-10-12T10:00:00Z",


### PR DESCRIPTION
## Summary

  Adds a new report flow for environments where Farm Calendar (FC) is not available. The existing observation/compost endpoints rely on FC to resolve `@id` references (parcel address, farm name, lat/long for satellite imagery).
   Without FC, those reports render with empty parcel/farm sections and no satellite tile.

  This PR introduces a parallel endpoint that:
  - Accepts a **pure JSON-LD observation array** (top-level `[ ... ]`) — not the `{"@graph": [...]}` envelope.
  - Takes parcel/farm details as **manual multipart form fields** (no FC lookups, no Nominatim).
  - Requires **no authentication**.
  - Stores PDFs in a shared `user_reports/standalone/` folder (instead of the per-user folder used by the auth'd endpoints).
  - Has a **dedicated unauthenticated GET** for retrieval.

  All existing endpoints, report generators, and schemas are **byte-for-byte unchanged**.

  ## New endpoints

  | Method | Path | Auth | Purpose |
  |---|---|---|---|
  | `POST` | `/api/v1/openagri-report/standalone-observation-report/` | None | Generate the PDF |
  | `GET`  | `/api/v1/openagri-report/standalone-observation-report/{report_id}/` | None | Retrieve the PDF |

  ## Behaviour notes

  - **Auth:** the standalone POST/GET are intentionally unauthenticated.
  - **Validation:** observations must be a JSON array of valid `CropObservation` JSON-LD objects. Malformed payloads return `400`. Existing endpoints' validation behaviour is unchanged.

Related issue: https://github.com/agstack/OpenAgri-ReportingService/issues/65
