### PR TITLE
Feature/field notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,54 @@ Response is uuid of generated PDF file.
 
 Response is uuid of generated PDF file.
 
+<h3>POST</h3>
+
+```
+/api/v1/openagri-report/field-notebook/
+```
+
+Generates a unified Field Notebook PDF aligned with European Field Notebook (farm diary) requirements. The report combines farm/parcel information, a forecasting pest-risk summary, and all agronomic activities (pest treatment, fertilization, irrigation) plus crop data and observations, in chronological order.
+
+**Requires Gatekeeper mode.** Data is fetched from Farm Calendar via the proxy; requests without Gatekeeper enabled return HTTP 400.
+
+## Request Params
+
+### parcel_id
+- **Type**: `str`
+- **Description**: Optional parcel filter.
+
+### from_date
+- **Type**: `date`
+- **Description**: Optional date filter (from which data is filtered).
+
+### to_date
+- **Type**: `date`
+- **Description**: Optional date filter (until which data is filtered).
+
+### include_irrigation
+- **Type**: `bool`
+- **Description**: Include the Irrigation Activities section. Defaults to `true`.
+
+### include_fertilization
+- **Type**: `bool`
+- **Description**: Include the Fertilization Activities section. Defaults to `true`.
+
+### include_pesticides
+- **Type**: `bool`
+- **Description**: Include the Pest Treatment Activities section. Defaults to `true`.
+
+### include_observations
+- **Type**: `bool`
+- **Description**: Include the Crop Data & Observations section. Defaults to `true`.
+
+### certification
+- **Type**: `QualityCertification` (optional request body)
+- **Description**: Optional quality certification details rendered in the observations section. Fields (all optional): `cert_type`, `cert_number`, `cert_issuing_body`, `cert_issue_date`, `cert_expiry_date`, `cert_notes`.
+
+## Response
+
+Response is uuid of generated PDF file, pollable via `GET /{report_id}/`.
+
 <h2>Pytest</h2>
 Pytest can be run on the same machine the service has been deployed to by moving into the app dir and running:
 

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -312,7 +312,7 @@ async def generate_field_notebook(
     European Field Notebook (farm diary) requirements:
 
     1. Farm & parcel information (name, VAT, contact, address, satellite map)
-    2. Forecasting models – last 15 days pest risk summary (requires REPORTING_FORECASTING_BASE_URL)
+    2. Forecasting models – last 15 days pest risk summary (TODO when implemented on FC && PDM)
     3. Pest treatment activities (all CropProtectionOperations, chronological)
     4. Fertilization activities (all FertilizationOperations, chronological)
     5. Irrigation activities (all IrrigationOperations, chronological)

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -14,10 +14,11 @@ from pydantic import UUID4
 
 from api import deps
 from core import settings
-from schemas import PDF
+from schemas import PDF, QualityCertification
 from utils import decode_jwt_token
 from utils.animals_report import process_animal_data
 from utils.farm_calendar_report import process_farm_calendar_data
+from utils.field_notebook_report import process_field_notebook_data
 from utils.irrig_fert_pest_report import process_irrigation_fertilization_data
 from fastapi.responses import FileResponse
 
@@ -284,6 +285,69 @@ async def generate_pesticides_report(
         parcel_id=parcel_id,
         irrigation_flag=False,
         pesticides_flag= True
+    )
+
+    return PDF(uuid=uuid_v4)
+
+
+@router.post("/field-notebook/", response_model=PDF)
+async def generate_field_notebook(
+    background_tasks: BackgroundTasks,
+    token=Depends(deps.get_current_user),
+    parcel_id: str = None,
+    from_date: datetime.date = None,
+    to_date: datetime.date = None,
+    # Activity section filters — all included by default
+    include_irrigation: bool = True,
+    include_fertilization: bool = True,
+    include_pesticides: bool = True,
+    include_observations: bool = True,
+    # Quality certification — optional request body
+    certification: Optional[QualityCertification] = None,
+):
+    """
+    Generates a unified Field Notebook PDF for a farm parcel.
+
+    Combines all agronomic activities in chronological order, aligned with
+    European Field Notebook (farm diary) requirements:
+
+    1. Farm & parcel information (name, VAT, contact, address, satellite map)
+    2. Forecasting models – last 15 days pest risk summary (requires REPORTING_FORECASTING_BASE_URL)
+    3. Pest treatment activities (all CropProtectionOperations, chronological)
+    4. Fertilization activities (all FertilizationOperations, chronological)
+    5. Irrigation activities (all IrrigationOperations, chronological)
+    6. Crop data & observations (all recorded observations + quality certification section)
+
+    Requires Gatekeeper mode. Data is fetched from Farm Calendar via the proxy.
+    Returns a UUID that can be polled via GET /{report_id}/.
+    """
+    if not settings.REPORTING_USING_GATEKEEPER:
+        raise HTTPException(
+            status_code=400,
+            detail="Field Notebook report requires Gatekeeper mode.",
+        )
+
+    uuid_v4 = str(uuid.uuid4())
+    user_id = decode_jwt_token(token)["user_id"]
+    uuid_of_pdf = f"{user_id}/{uuid_v4}"
+
+    background_tasks.add_task(
+        process_field_notebook_data,
+        token=token,
+        pdf_file_name=uuid_of_pdf,
+        parcel_id=parcel_id,
+        from_date=from_date,
+        to_date=to_date,
+        include_irrigation=include_irrigation,
+        include_fertilization=include_fertilization,
+        include_pesticides=include_pesticides,
+        include_observations=include_observations,
+        cert_type=certification.cert_type if certification else None,
+        cert_number=certification.cert_number if certification else None,
+        cert_issuing_body=certification.cert_issuing_body if certification else None,
+        cert_issue_date=certification.cert_issue_date if certification else None,
+        cert_expiry_date=certification.cert_expiry_date if certification else None,
+        cert_notes=certification.cert_notes if certification else None,
     )
 
     return PDF(uuid=uuid_v4)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -33,11 +33,17 @@ class Settings(BaseSettings):
         "operations": "/CompostOperations/",
         "turning_operations": "/CompostTurningOperations/",
         "activities": "/FarmCalendarActivities/",
+        "crops": "/FarmCrops/",
         "parcel": "/FarmParcels/",
         "animals": "/FarmAnimals/",
         "materials": "/AddRawMaterialOperations/",
         "machines": "/AgriculturalMachines/",
         "farm": "/Farm/"
+    }
+
+    REPORTING_FORECASTING_BASE_URL: str = ""
+    REPORTING_FORECASTING_URLS: dict = {
+        "pest_risk": "/PestRisk/",
     }
 
     PDF_DIRECTORY: str = "user_reports/"

--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,7 @@ async def lifespan(fa: FastAPI):
 
 
 app = FastAPI(
-    title="Reporting service", openapi_url="/api/v1/openapi.json"
+    title="Reporting service", openapi_url="/api/v1/openapi.json", lifespan=lifespan
 )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,7 @@ async def lifespan(fa: FastAPI):
 
 
 app = FastAPI(
-    title="Reporting service", openapi_url="/api/v1/openapi.json", lifespan=lifespan
+    title="Reporting service", openapi_url="/api/v1/openapi.json"
 )
 
 

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,4 +1,4 @@
-from .generic import *
+from .generic import Message, PDF, QualityCertification
 from .token import *
 from .user import *
 from .irrigation import *

--- a/app/schemas/generic.py
+++ b/app/schemas/generic.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 
@@ -7,3 +9,12 @@ class Message(BaseModel):
 
 class PDF(BaseModel):
     uuid: str
+
+
+class QualityCertification(BaseModel):
+    cert_type: Optional[str] = None
+    cert_number: Optional[str] = None
+    cert_issuing_body: Optional[str] = None
+    cert_issue_date: Optional[str] = None
+    cert_expiry_date: Optional[str] = None
+    cert_notes: Optional[str] = None

--- a/app/utils/field_notebook_report.py
+++ b/app/utils/field_notebook_report.py
@@ -1,0 +1,545 @@
+import datetime
+import io
+import logging
+import os
+
+from fastapi import HTTPException
+from geopy.geocoders import Nominatim
+
+from core import settings
+from schemas import IrrigationOperation, FertilizationOperation, CropProtectionOperation
+from schemas.compost import CropObservation
+from utils import (
+    EX,
+    add_fonts,
+    decode_dates_filters,
+    display_pdf_parcel_details,
+    FarmInfo,
+)
+from utils.generate_aggregation_data import get_pest_from_obj
+from utils.json_handler import make_get_request
+from utils.satellite_image_get import fetch_wms_image, SatelliteImageException
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+geolocator = Nominatim(user_agent="reporting_open_agri_app", timeout=5)
+
+
+def _fetch_list(url_key: str, token: str, params: dict) -> list:
+    """Generic list fetch from farmcalendar. Returns [] on any failure."""
+    result = make_get_request(
+        url=f"{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS[url_key]}",
+        token=token,
+        params=params,
+    )
+    return result if isinstance(result, list) else []
+
+
+def _base_params(parcel_id: str, from_date, to_date) -> dict:
+    params = {"format": "json"}
+    if parcel_id:
+        params["parcel"] = parcel_id
+    decode_dates_filters(params, from_date, to_date)
+    return params
+
+
+def _fetch_crops_for_parcel(parcel_id: str, token: str) -> list:
+    """Fetch all crops linked via hasAgriCrop on the parcel. Returns [] on any failure."""
+    if not parcel_id:
+        return []
+    parcel_data = make_get_request(
+        url=f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["parcel"]}{parcel_id}/',
+        token=token,
+        params={"format": "json"},
+    )
+    if not parcel_data or not isinstance(parcel_data, dict):
+        return []
+    has_agri_crop = parcel_data.get("hasAgriCrop") or []
+    if not has_agri_crop:
+        return []
+    crops = []
+    for crop_ref in has_agri_crop:
+        crop_id_full = (crop_ref or {}).get("@id", "")
+        if not crop_id_full:
+            continue
+        crop_uuid = crop_id_full.split(":")[-1]
+        if not crop_uuid:
+            continue
+        crop_data = make_get_request(
+            url=f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["crops"]}{crop_uuid}/',
+            token=token,
+            params={"format": "json"},
+        )
+        if crop_data and isinstance(crop_data, dict):
+            crops.append(crop_data)
+    return crops
+
+
+def _fetch_forecasting(token: str, parcel_id: str) -> list:
+    """Fetch pest-risk forecasting data. Returns [] when not configured or unavailable."""
+    if not settings.REPORTING_FORECASTING_BASE_URL:
+        return []
+    params = {"format": "json"}
+    if parcel_id:
+        params["parcel"] = parcel_id
+    pest_risk_path = settings.REPORTING_FORECASTING_URLS.get("pest_risk", "/PestRisk/")
+    result = make_get_request(
+        url=f"{settings.REPORTING_FORECASTING_BASE_URL}{pest_risk_path}",
+        token=token,
+        params=params,
+    )
+    return result if isinstance(result, list) else []
+
+
+def _section_header(pdf: EX, number: str, title: str) -> None:
+    pdf.ln(4)
+    y = pdf.get_y()
+    pdf.set_fill_color(240, 240, 240)
+    pdf.line(pdf.l_margin, y, pdf.w - pdf.r_margin, y)
+    pdf.set_font("FreeSerif", "B", 13)
+    pdf.set_x(pdf.l_margin + 2)
+    pdf.cell(0, 10, f"{number}. {title}", ln=True)
+    pdf.ln(2)
+
+
+def _kv(pdf: EX, label: str, value: str) -> None:
+    pdf.set_font("FreeSerif", "B", 10)
+    pdf.cell(52, 7, label)
+    pdf.set_font("FreeSerif", "", 10)
+    pdf.multi_cell(0, 7, value or "\u2014", ln=True)
+
+
+def _no_data(pdf: EX, msg: str) -> None:
+    pdf.set_font("FreeSerif", "", 10)
+    pdf.cell(0, 8, msg, ln=True)
+
+
+def _render_crops_section(pdf: EX, crops: list) -> None:
+    pdf.ln(3)
+    pdf.set_font("FreeSerif", "B", 11)
+    pdf.cell(0, 8, "Crops", ln=True)
+    pdf.ln(1)
+    if not crops:
+        _no_data(pdf, "No crops associated with this parcel.")
+        return
+    pdf.set_font("FreeSerif", "B", 10)
+    with pdf.table(text_align="CENTER") as table:
+        row = table.row()
+        row.cell("Name")
+        row.cell("Description")
+        row.cell("Status")
+        row.cell("Growth Stage")
+        row.cell("Species")
+        row.cell("Variety")
+        pdf.set_font("FreeSerif", "", 9)
+        for crop in crops:
+            crop_species = crop.get("cropSpecies") or {}
+            row = table.row()
+            row.cell(crop.get("name") or "\u2014")
+            row.cell(crop.get("description") or "\u2014")
+            row.cell(str(crop["status"]) if crop.get("status") is not None else "\u2014")
+            row.cell(crop.get("growth_stage") or "\u2014")
+            row.cell(crop_species.get("name") or "\u2014")
+            row.cell(crop_species.get("variety") or "\u2014")
+
+
+def create_field_notebook_pdf(
+    parcel_id: str,
+    token: str,
+    from_date=None,
+    to_date=None,
+    irrigation_ops: list = None,
+    fertilization_ops: list = None,
+    pesticide_ops: list = None,
+    observations: list = None,
+    forecasting_data: list = None,
+    crops: list = None,
+    cert_type: str = None,
+    cert_number: str = None,
+    cert_issuing_body: str = None,
+    cert_issue_date: str = None,
+    cert_expiry_date: str = None,
+    cert_notes: str = None,
+    include_irrigation: bool = True,
+    include_fertilization: bool = True,
+    include_pesticides: bool = True,
+    include_observations: bool = True,
+) -> EX:
+    irrigation_ops = irrigation_ops or []
+    fertilization_ops = fertilization_ops or []
+    pesticide_ops = pesticide_ops or []
+    observations = observations or []
+    forecasting_data = forecasting_data or []
+    crops = crops or []
+
+    pdf = EX()
+    add_fonts(pdf)
+    pdf.set_auto_page_break(auto=True, margin=20)
+    pdf.add_page()
+    pdf.ln(2)
+
+    today = datetime.datetime.now().strftime("%d/%m/%Y")
+    from_str = from_date.strftime("%d/%m/%Y") if from_date else "\u2014"
+    to_str = to_date.strftime("%d/%m/%Y") if to_date else today
+
+    pdf.set_font("FreeSerif", "B", 18)
+    pdf.cell(0, 12, "Field Notebook", ln=True, align="C")
+    pdf.set_font("FreeSerif", "", 9)
+    pdf.cell(
+        0, 6,
+        f"Generated: {today}     |     Reporting period: {from_str} \u2013 {to_str}",
+        ln=True, align="C",
+    )
+    pdf.ln(4)
+    y = pdf.get_y()
+    pdf.line(pdf.l_margin, y, pdf.w - pdf.r_margin, y)
+
+    _section_header(pdf, "1", "Farm & Parcel Information")
+
+    parcel_data = None
+    if parcel_id and settings.REPORTING_USING_GATEKEEPER:
+        parcel_data = display_pdf_parcel_details(pdf, parcel_id, geolocator, token)
+    else:
+        _no_data(pdf, "Parcel details require Gatekeeper mode to be enabled.")
+
+    _render_crops_section(pdf, crops)
+
+    if parcel_data and parcel_data.lat and parcel_data.long:
+        try:
+            image_bytes = fetch_wms_image(parcel_data.lat, parcel_data.long)
+            pdf.ln(2)
+            x_start = (pdf.w - 120) / 2
+            pdf.set_x(x_start)
+            pdf.image(io.BytesIO(image_bytes), type="png", w=120)
+            pdf.ln(2)
+        except SatelliteImageException:
+            logger.info("Satellite image unavailable, continuing without it.")
+
+    pdf.add_page()
+    _section_header(pdf, "2", "Forecasting Models \u2013 Last 15 Days")
+
+    if not forecasting_data:
+        _no_data(pdf, "No forecasting data available (service not configured or no data returned).")
+    else:
+        pdf.set_font("FreeSerif", "B", 10)
+        with pdf.table(text_align="CENTER") as table:
+            row = table.row()
+            row.cell("Pest / Model")
+            row.cell("Risk Level")
+            row.cell("Date")
+            row.cell("Notes")
+            pdf.set_font("FreeSerif", "", 9)
+            for entry in forecasting_data:
+                row = table.row()
+                row.cell(str(entry.get("pest") or entry.get("name") or "\u2014"))
+                row.cell(str(entry.get("riskLevel") or entry.get("risk_level") or "\u2014"))
+                row.cell(str(entry.get("date") or "\u2014"))
+                row.cell(str(entry.get("notes") or entry.get("details") or "\u2014"))
+
+    _sec = [3]
+
+    def _next_sec() -> str:
+        n = str(_sec[0])
+        _sec[0] += 1
+        return n
+
+    if include_pesticides:
+        pdf.add_page()
+        _section_header(pdf, _next_sec(), "Pest Treatment Activities")
+
+        if not pesticide_ops:
+            _no_data(pdf, "No pesticide treatment activities recorded for this period.")
+        else:
+            try:
+                pesticide_ops.sort(key=lambda x: x.hasStartDatetime or datetime.datetime.min)
+            except Exception:
+                pass
+            pdf.set_font("FreeSerif", "B", 10)
+            with pdf.table(text_align="CENTER") as table:
+                row = table.row()
+                row.cell("Date")
+                row.cell("Title")
+                row.cell("Pesticide")
+                row.cell("Dose")
+                row.cell("Unit")
+                row.cell("Agent")
+                pdf.set_font("FreeSerif", "", 9)
+                for op in pesticide_ops:
+                    row = table.row()
+                    row.cell(
+                        op.hasStartDatetime.strftime("%d/%m/%Y")
+                        if op.hasStartDatetime else "\u2014"
+                    )
+                    row.cell(op.title or "\u2014")
+                    row.cell(get_pest_from_obj(op, token) or "\u2014")
+                    row.cell(
+                        str(op.hasAppliedAmount.numericValue)
+                        if op.hasAppliedAmount else "\u2014"
+                    )
+                    row.cell(
+                        op.hasAppliedAmount.unit
+                        if op.hasAppliedAmount else "\u2014"
+                    )
+                    row.cell(op.responsibleAgent or "\u2014")
+
+    if include_fertilization:
+        pdf.add_page()
+        _section_header(pdf, _next_sec(), "Fertilization Activities")
+
+        if not fertilization_ops:
+            _no_data(pdf, "No fertilization activities recorded for this period.")
+        else:
+            try:
+                fertilization_ops.sort(key=lambda x: x.hasStartDatetime or datetime.datetime.min)
+            except Exception:
+                pass
+            pdf.set_font("FreeSerif", "B", 10)
+            with pdf.table(text_align="CENTER") as table:
+                row = table.row()
+                row.cell("Date")
+                row.cell("Title")
+                row.cell("Fertilizer")
+                row.cell("Application Method")
+                row.cell("Dose")
+                row.cell("Unit")
+                row.cell("Agent")
+                pdf.set_font("FreeSerif", "", 9)
+                for op in fertilization_ops:
+                    row = table.row()
+                    row.cell(
+                        op.hasStartDatetime.strftime("%d/%m/%Y")
+                        if op.hasStartDatetime else "\u2014"
+                    )
+                    row.cell(op.title or "\u2014")
+                    fertilizer_name = "\u2014"
+                    if op.usesFertilizer:
+                        fertilizer_name = (
+                            op.usesFertilizer.get("name")
+                            or op.usesFertilizer.get("@id", "").split(":")[-1]
+                            or "Yes"
+                        )
+                    row.cell(fertilizer_name)
+                    row.cell(op.hasApplicationMethod or "\u2014")
+                    row.cell(
+                        str(op.hasAppliedAmount.numericValue)
+                        if op.hasAppliedAmount else "\u2014"
+                    )
+                    row.cell(
+                        op.hasAppliedAmount.unit
+                        if op.hasAppliedAmount else "\u2014"
+                    )
+                    row.cell(op.responsibleAgent or "\u2014")
+
+    if include_irrigation:
+        pdf.add_page()
+        _section_header(pdf, _next_sec(), "Irrigation Activities")
+
+        if not irrigation_ops:
+            _no_data(pdf, "No irrigation activities recorded for this period.")
+        else:
+            try:
+                irrigation_ops.sort(key=lambda x: x.hasStartDatetime or datetime.datetime.min)
+            except Exception:
+                pass
+            pdf.set_font("FreeSerif", "B", 10)
+            with pdf.table(text_align="CENTER") as table:
+                row = table.row()
+                row.cell("Start Date")
+                row.cell("End Date")
+                row.cell("Title")
+                row.cell("Irrigation System")
+                row.cell("Dose")
+                row.cell("Unit")
+                row.cell("Agent")
+                pdf.set_font("FreeSerif", "", 9)
+                for op in irrigation_ops:
+                    row = table.row()
+                    row.cell(
+                        op.hasStartDatetime.strftime("%d/%m/%Y")
+                        if op.hasStartDatetime else "\u2014"
+                    )
+                    row.cell(
+                        op.hasEndDatetime.strftime("%d/%m/%Y")
+                        if op.hasEndDatetime else "\u2014"
+                    )
+                    row.cell(op.title or "\u2014")
+                    sys_name = "\u2014"
+                    if isinstance(op.usesIrrigationSystem, dict):
+                        sys_name = op.usesIrrigationSystem.get("name") or "\u2014"
+                    elif op.usesIrrigationSystem:
+                        sys_name = op.usesIrrigationSystem
+                    row.cell(sys_name)
+                    row.cell(
+                        str(op.hasAppliedAmount.numericValue)
+                        if op.hasAppliedAmount else "\u2014"
+                    )
+                    row.cell(
+                        op.hasAppliedAmount.unit
+                        if op.hasAppliedAmount else "\u2014"
+                    )
+                    row.cell(op.responsibleAgent or "\u2014")
+
+    if include_observations:
+        pdf.add_page()
+        _section_header(pdf, _next_sec(), "Crop Data & Observations")
+
+        if not observations:
+            _no_data(pdf, "No observations recorded for this period.")
+        else:
+            try:
+                observations.sort(
+                    key=lambda x: x.hasStartDatetime or x.phenomenonTime or datetime.datetime.min
+                )
+            except Exception:
+                pass
+            pdf.set_font("FreeSerif", "B", 10)
+            with pdf.table(text_align="CENTER") as table:
+                row = table.row()
+                row.cell("Date")
+                row.cell("Title")
+                row.cell("Observed Property")
+                row.cell("Value")
+                row.cell("Unit")
+                row.cell("Details")
+                pdf.set_font("FreeSerif", "", 9)
+                for obs in observations:
+                    row = table.row()
+                    date_val = obs.hasStartDatetime or obs.phenomenonTime
+                    row.cell(
+                        date_val.strftime("%d/%m/%Y") if date_val else "\u2014"
+                    )
+                    row.cell(obs.title or "\u2014")
+                    row.cell(obs.observedProperty or "\u2014")
+                    row.cell(
+                        str(obs.hasResult.hasValue)
+                        if obs.hasResult and obs.hasResult.hasValue else "\u2014"
+                    )
+                    row.cell(
+                        obs.hasResult.unit
+                        if obs.hasResult and obs.hasResult.unit else "\u2014"
+                    )
+                    row.cell(obs.details or "\u2014")
+
+    pdf.ln(8)
+    pdf.set_font("FreeSerif", "B", 12)
+    pdf.cell(0, 8, "Quality Certification", ln=True)
+    y = pdf.get_y()
+    pdf.line(pdf.l_margin, y, pdf.w - pdf.r_margin, y)
+    pdf.ln(4)
+    cert_fields = [
+        ("Certification Type", cert_type),
+        ("Certification Number / Reference", cert_number),
+        ("Issuing Body", cert_issuing_body),
+        ("Issue Date", cert_issue_date),
+        ("Expiry Date", cert_expiry_date),
+        ("Notes", cert_notes),
+    ]
+    for label, value in cert_fields:
+        pdf.set_font("FreeSerif", "B", 10)
+        pdf.cell(72, 9, f"{label}:")
+        pdf.set_font("FreeSerif", "", 10)
+        if value:
+            pdf.multi_cell(0, 9, value, ln=True)
+        else:
+            pdf.cell(0, 9, "_____________________________________________", ln=True)
+        pdf.ln(1)
+
+    return pdf
+
+
+def process_field_notebook_data(
+    token: str,
+    pdf_file_name: str,
+    parcel_id: str = None,
+    from_date: datetime.date = None,
+    to_date: datetime.date = None,
+    cert_type: str = None,
+    cert_number: str = None,
+    cert_issuing_body: str = None,
+    cert_issue_date: str = None,
+    cert_expiry_date: str = None,
+    cert_notes: str = None,
+    include_irrigation: bool = True,
+    include_fertilization: bool = True,
+    include_pesticides: bool = True,
+    include_observations: bool = True,
+) -> None:
+    """
+    Fetch all field activity data for a parcel and generate a unified Field Notebook PDF.
+    """
+    if not settings.REPORTING_USING_GATEKEEPER:
+        raise HTTPException(
+            status_code=400,
+            detail="Field Notebook report requires Gatekeeper mode (data is fetched from Farm Calendar service).",
+        )
+
+    params = _base_params(parcel_id, from_date, to_date)
+
+    crops = _fetch_crops_for_parcel(parcel_id, token)
+
+    raw_irrigations = _fetch_list("irrigations", token, params) if include_irrigation else []
+    raw_fertilizations = _fetch_list("fertilization", token, params) if include_fertilization else []
+    raw_pesticides = _fetch_list("pesticides", token, params) if include_pesticides else []
+
+    raw_observations = _fetch_list("observations", token, params) if include_observations else []
+
+    forecasting_data = _fetch_forecasting(token, parcel_id)
+
+    try:
+        irrigation_ops = [IrrigationOperation.model_validate(item) for item in raw_irrigations]
+    except Exception as e:
+        logger.error(f"Error parsing irrigation operations: {e}")
+        irrigation_ops = []
+
+    try:
+        fertilization_ops = [FertilizationOperation.model_validate(item) for item in raw_fertilizations]
+    except Exception as e:
+        logger.error(f"Error parsing fertilization operations: {e}")
+        fertilization_ops = []
+
+    try:
+        pesticide_ops = [CropProtectionOperation.model_validate(item) for item in raw_pesticides]
+    except Exception as e:
+        logger.error(f"Error parsing pesticide operations: {e}")
+        pesticide_ops = []
+
+    try:
+        observations = [CropObservation.model_validate(item) for item in raw_observations]
+    except Exception as e:
+        logger.error(f"Error parsing observations: {e}")
+        observations = []
+
+    try:
+        pdf = create_field_notebook_pdf(
+            parcel_id=parcel_id,
+            token=token,
+            from_date=from_date,
+            to_date=to_date,
+            irrigation_ops=irrigation_ops,
+            fertilization_ops=fertilization_ops,
+            pesticide_ops=pesticide_ops,
+            observations=observations,
+            forecasting_data=forecasting_data,
+            crops=crops,
+            cert_type=cert_type,
+            cert_number=cert_number,
+            cert_issuing_body=cert_issuing_body,
+            cert_issue_date=cert_issue_date,
+            cert_expiry_date=cert_expiry_date,
+            cert_notes=cert_notes,
+            include_irrigation=include_irrigation,
+            include_fertilization=include_fertilization,
+            include_pesticides=include_pesticides,
+            include_observations=include_observations,
+        )
+    except Exception as e:
+        logger.error(f"Field Notebook PDF generation failed: {e}")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Field Notebook PDF generation failed: {e}",
+        )
+
+    pdf_dir = f"{settings.PDF_DIRECTORY}{pdf_file_name}"
+    os.makedirs(os.path.dirname(f"{pdf_dir}.pdf"), exist_ok=True)
+    pdf.output(f"{pdf_dir}.pdf")

--- a/scripts/report_client.py
+++ b/scripts/report_client.py
@@ -10,6 +10,7 @@ MAX_RETRIES = 10
 # Seconds to wait between check attempts
 RETRY_DELAY_SECONDS = 3
 
+
 # USAGE EXAMPLES:
 
 # python report_client.py --type animal --token "your-long-auth-token-here" --file "path/to/animal_data.json"


### PR DESCRIPTION
 Summary                                                                                                                                                                                                                                                                                                                                                                                                                                                             
  Adds a new Field Notebook PDF report — a unified farm-diary document aligned with European Field Notebook requirements — plus supporting schema/config changes.                                                                  
                  
  Changes

  - New endpoint: POST /field-notebook/ in app/api/api_v1/endpoints/report.py
    - Optional filters: parcel_id, from_date, to_date
    - Section toggles (default True): include_irrigation, include_fertilization, include_pesticides, include_observations
    - Optional body: QualityCertification (type, number, issuing body, issue/expiry dates, notes)
    - Requires Gatekeeper mode; runs as a background task and returns a UUID pollable via GET /{report_id}/
  - New generator: app/utils/field_notebook_report.py produces a 6-section PDF:
    a. Farm & parcel info (name, VAT, contact, address, satellite map, linked crops)
    b. Forecasting models — last 15 days pest risk (stubbed; populated when forecasting service is configured)
    c. Pest treatment activities (chronological)
    d. Fertilization activities (chronological)
    e. Irrigation activities (chronological)
    f. Crop data & observations + quality certification block
 

  - Forecasting section gracefully renders a "not configured" message when REPORTING_FORECASTING_BASE_URL is unset, so no env changes are required to ship.
  - Activities are sorted chronologically with a defensive try/except so malformed dates don't break the report.
  - All list fetches fall back to [] on failure — a partially available farm still produces a valid PDF.

Example PDF: [report_example.pdf](https://github.com/user-attachments/files/26959114/report_example.pdf)

Issue related: https://github.com/agstack/OpenAgri-ReportingService/issues/64
