### PR TITLE
fix: Skip machinery/parcel lookup for compost report when gatekeeper …

### DIFF
--- a/app/utils/farm_calendar_report.py
+++ b/app/utils/farm_calendar_report.py
@@ -264,26 +264,27 @@ def create_farm_calendar_pdf(
                             for machinery in operation.usesAgriculturalMachinery
                         ]
                     )
-                    agr_mach_id = (
-                        operation.usesAgriculturalMachinery[0]
-                        .get("@id", "N/A:N/A")
-                        .split(":")[-1]
-                    )
-                    agr_resp = make_get_request(
-                        url=f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["machines"]}{agr_mach_id}/',
-                        token=token,
-                        params={"format": "json"},
-                    )
-                    if agr_resp:
-                        parcel_id = (
-                            agr_resp.get("hasAgriParcel", {})
+                    if settings.REPORTING_USING_GATEKEEPER:
+                        agr_mach_id = (
+                            operation.usesAgriculturalMachinery[0]
                             .get("@id", "N/A:N/A")
                             .split(":")[-1]
                         )
-                        parcel_data, farm = get_parcel_info(
-                            parcel_id, token, geolocator
+                        agr_resp = make_get_request(
+                            url=f'{settings.REPORTING_FARMCALENDAR_BASE_URL}{settings.REPORTING_FARMCALENDAR_URLS["machines"]}{agr_mach_id}/',
+                            token=token,
+                            params={"format": "json"},
                         )
-                        address = parcel_data.address
+                        if agr_resp:
+                            parcel_id = (
+                                agr_resp.get("hasAgriParcel", {})
+                                .get("@id", "N/A:N/A")
+                                .split(":")[-1]
+                            )
+                            parcel_data, farm = get_parcel_info(
+                                parcel_id, token, geolocator
+                            )
+                            address = parcel_data.address
 
                 row.cell(f"{machinery_ids}")
                 if not parcel_defined:


### PR DESCRIPTION
Summary
- The compost report looks up each operation's machinery via _make_get_request()_ unconditionally, unlike _get_parcel_info()_ which already skips itself when _REPORTING_USING_GATEKEEPER_ is _False_.
- With gatekeeper disabled, this call always fails, and Docker's DNS resolver occasionally takes several seconds to give up on it - noticed as noticeably slower compost-report generation during stress testing.
- Guards the lookup with the same _REPORTING_USING_GATEKEEPER_ check _get_parcel_info()_ already uses.

Test plan
- Reproduced the slowdown before the fix.
- Confirmed it's gone after the fix, no behavior change with gatekeeper enabled.